### PR TITLE
Add configurable chat model

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,4 +86,7 @@ Deployable-Knowledge is an offline-capable Retrieval-Augmented Generation (RAG) 
 
 3. Ensure `ollama` is running and accessible.
 
-4. Navigate to `http://localhost:8000` in your browser.
+4. *(Optional)* Set the `OLLAMA_MODEL` environment variable if you want to use a
+   different chat model than the default `mistral:7b`.
+
+5. Navigate to `http://localhost:8000` in your browser.

--- a/app/routes/api_chat_search.py
+++ b/app/routes/api_chat_search.py
@@ -7,7 +7,7 @@ from sklearn.preprocessing import StandardScaler
 import numpy as np
 
 from utility.embedding_and_storing import db
-from config import OLLAMA_URL
+from config import OLLAMA_URL, OLLAMA_MODEL
 
 router = APIRouter()
 
@@ -31,7 +31,7 @@ def update_summary(old_summary: str, user_msg: str, assistant_msg: str) -> str:
         """.strip()
     try:
         response = requests.post(OLLAMA_URL, json={
-            "model": "mistral:7b",
+            "model": OLLAMA_MODEL,
             "prompt": prompt,
             "stream": False
         })
@@ -119,7 +119,7 @@ async def chat(
             Assistant:"""
 
         # Generate response
-        response = requests.post(OLLAMA_URL, json={"model": "mistral:7b", "prompt": prompt})
+        response = requests.post(OLLAMA_URL, json={"model": OLLAMA_MODEL, "prompt": prompt})
         chatbot_response = response.json().get("response", "[Error: No response]")
 
         # Format response
@@ -244,7 +244,7 @@ async def chat_stream(
         def event_stream():
             response = requests.post(
                 OLLAMA_URL,
-                json={"model": "mistral:7b", "prompt": prompt, "stream": True},
+                json={"model": OLLAMA_MODEL, "prompt": prompt, "stream": True},
                 stream=True
             )
 

--- a/config.py
+++ b/config.py
@@ -21,3 +21,4 @@ CHUNKING_METHOD_OPTIONS = ["sentences", "semantics", "graph", "paragraphs", "dyn
 
 # === Ollama ===
 OLLAMA_URL = os.getenv("OLLAMA_URL", "http://localhost:11434/api/generate")
+OLLAMA_MODEL = os.getenv("OLLAMA_MODEL", "mistral:7b")


### PR DESCRIPTION
## Summary
- make ollama model configurable via `OLLAMA_MODEL` in `config.py`
- update chat routes to use the configured model
- document the new env variable in the README

## Testing
- `python3 -m py_compile config.py app/routes/api_chat_search.py`

------
https://chatgpt.com/codex/tasks/task_e_6883f66bcb90832ca2251305c7144e0a