### PR TITLE
Refactor session management and improve logging

### DIFF
--- a/utility/chat_state.py
+++ b/utility/chat_state.py
@@ -1,86 +1,129 @@
+"""Chat session and exchange data models.
+
+This module defines lightweight data containers used to persist chat
+history and session level metadata.  The previous implementation used
+ad-hoc classes with a mixture of attribute names (e.g. ``llm_response``)
+which made it difficult to work with the objects consistently.  The
+refactored version below leverages :mod:`dataclasses` to provide a
+clear, typed structure and introduces a single ``assistant`` field for
+LLM responses.  For backwards compatibility the loader understands the
+old ``llm_response`` key.
+"""
+
+from __future__ import annotations
+
 import uuid
-from typing import List, Optional
+from dataclasses import dataclass, field
+from typing import List, Optional, Dict
 
 
+@dataclass
 class ChatExchange:
-    def __init__(
-        self,
-        user: str,
-        context_used: List[dict],
-        rag_prompt: str,
-        llm_response: str,
-        html_response: str
-    ):
-        self.user = user
-        self.context_used = context_used
-        self.rag_prompt = rag_prompt
-        self.llm_response = llm_response
-        self.html_response = html_response
+    """Represents a single interaction within a chat session."""
 
-    def to_dict(self):
+    user: str
+    context_used: List[Dict]
+    rag_prompt: str
+    assistant: str
+    html_response: str
+
+    # ------------------------------------------------------------------
+    # Serialization helpers
+    # ------------------------------------------------------------------
+    def to_dict(self) -> Dict:
         return {
             "user": self.user,
             "context_used": self.context_used,
             "rag_prompt": self.rag_prompt,
-            "llm_response": self.llm_response,
-            "html_response": self.html_response
+            "assistant": self.assistant,
+            "html_response": self.html_response,
         }
 
     @classmethod
-    def from_dict(cls, data):
+    def from_dict(cls, data: Dict) -> "ChatExchange":
+        """Create an exchange from serialized data.
+
+        Both ``assistant`` and the legacy ``llm_response`` keys are
+        supported when restoring older session files.
+        """
+
         return cls(
-            user=data["user"],
+            user=data.get("user", ""),
             context_used=data.get("context_used", []),
             rag_prompt=data.get("rag_prompt", ""),
-            llm_response=data.get("llm_response", ""),
-            html_response=data.get("html_response", "")
+            assistant=data.get("assistant") or data.get("llm_response", ""),
+            html_response=data.get("html_response", ""),
         )
 
 
+@dataclass
 class ChatSession:
-    def __init__(
+    """Container for a user's ongoing chat session."""
+
+    session_id: str
+    history: List[ChatExchange] = field(default_factory=list)
+    summary: str = ""
+    inactive_sources: List[str] = field(default_factory=list)
+    persona: Optional[str] = None
+
+    # ------------------------------------------------------------------
+    # Construction helpers
+    # ------------------------------------------------------------------
+    @classmethod
+    def new(cls, session_id: Optional[str] = None) -> "ChatSession":
+        """Create a new chat session with a random identifier."""
+
+        return cls(session_id=session_id or str(uuid.uuid4()))
+
+    # ------------------------------------------------------------------
+    # Mutation helpers
+    # ------------------------------------------------------------------
+    def add_exchange(
         self,
-        session_id: str,
-        history: Optional[List[ChatExchange]] = None,
-        summary: str = "",
-        inactive_sources: Optional[List[str]] = None,
-        persona: Optional[str] = None
-    ):
-        self.session_id = session_id
-        self.history = history or []
-        self.summary = summary
-        self.inactive_sources = inactive_sources or []
-        self.persona = persona
+        user: str,
+        context_used: List[Dict],
+        rag_prompt: str,
+        assistant: str,
+        html_response: str,
+    ) -> None:
+        """Append a new exchange to the session history."""
 
-    def add_exchange(self, user, context_used, rag_prompt, llm_response, html_response):
-        self.history.append(ChatExchange(
-            user=user,
-            context_used=context_used,
-            rag_prompt=rag_prompt,
-            llm_response=llm_response,
-            html_response=html_response
-        ))
+        self.history.append(
+            ChatExchange(
+                user=user,
+                context_used=context_used,
+                rag_prompt=rag_prompt,
+                assistant=assistant,
+                html_response=html_response,
+            )
+        )
 
-    def to_dict(self):
+    def trim_history(self, max_length: int) -> None:
+        """Keep only the most recent ``max_length`` exchanges."""
+
+        if len(self.history) > max_length:
+            self.history = self.history[-max_length:]
+
+    # ------------------------------------------------------------------
+    # Serialization helpers
+    # ------------------------------------------------------------------
+    def to_dict(self) -> Dict:
         return {
             "session_id": self.session_id,
             "summary": self.summary,
             "history": [exchange.to_dict() for exchange in self.history],
             "inactive_sources": self.inactive_sources,
-            "persona": self.persona
+            "persona": self.persona,
         }
 
     @classmethod
-    def from_dict(cls, data):
+    def from_dict(cls, data: Dict) -> "ChatSession":
         session = cls(
-            session_id=data["session_id"],
+            session_id=data.get("session_id", ""),
             summary=data.get("summary", ""),
             inactive_sources=data.get("inactive_sources", []),
-            persona=data.get("persona")
+            persona=data.get("persona"),
         )
         session.history = [ChatExchange.from_dict(e) for e in data.get("history", [])]
         return session
 
-    @classmethod
-    def new(cls, session_id=None):
-        return cls(session_id=session_id or str(uuid.uuid4()))

--- a/utility/db_manager.py
+++ b/utility/db_manager.py
@@ -12,15 +12,7 @@ import chromadb
 from chromadb.config import Settings
 
 class DBManager:
-    """from db_manager import ChromaDBManager
-from your_segmentation_module import TopDownSegmenter
-
-db = DBManager("chroma_db", "test_collection")
-segmenter = TopDownSegmenter()
-
-segments = segmenter.segment(text)
-db.add_segments(segments, strategy_name="top_down", source="contract_001.txt", tags=["legal"])
-"""
+    """Wrapper around ChromaDB providing embedding and storage helpers."""
     def __init__(self, persist_dir: str, collection_name: str):
         self.client = chromadb.PersistentClient(path=str(persist_dir), settings=Settings(anonymized_telemetry=False))        
         self.collection = self.client.get_or_create_collection(collection_name)

--- a/utility/llm_prompt_engine.py
+++ b/utility/llm_prompt_engine.py
@@ -15,8 +15,7 @@ def build_prompt(
     persona: Optional[str] = None
 ) -> str:
     history_block = "\n".join(
-        f"User: {ex.user}\nAssistant: {getattr(ex, 'assistant', '')}"
-        for ex in history[-3:]
+        f"User: {ex.user}\nAssistant: {ex.assistant}" for ex in history[-3:]
     )
 
     context_string = "\n\n".join(

--- a/utility/logger.py
+++ b/utility/logger.py
@@ -1,0 +1,29 @@
+"""Simple logging setup for the application.
+
+The project previously relied heavily on ``print`` statements which made
+it difficult to control log verbosity and collect diagnostics.  This
+module exposes a helper :func:`get_logger` that configures a standard
+Python :class:`logging.Logger` with a consistent format.  Individual
+modules can import and use it instead of ``print``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+
+def get_logger(name: Optional[str] = None) -> logging.Logger:
+    """Return a module-level logger with basic configuration."""
+
+    logger = logging.getLogger(name if name else "deployable")
+    if not logger.handlers:
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(
+            "%(asctime)s - %(levelname)s - %(name)s - %(message)s"
+        )
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+        logger.setLevel(logging.INFO)
+    return logger
+

--- a/utility/session_store.py
+++ b/utility/session_store.py
@@ -1,49 +1,69 @@
+"""Filesystem backed store for :class:`ChatSession` objects."""
+
 import json
 from pathlib import Path
 from typing import Dict, List, Optional
+
 from utility.chat_state import ChatSession
+from utility.logger import get_logger
+
 
 SESSION_DIR = Path("sessions")
 SESSION_DIR.mkdir(exist_ok=True)
 
+logger = get_logger(__name__)
+
+
 class SessionStore:
+    """Persist chat sessions as JSON files on disk."""
+
     def __init__(self, storage_path: Path = SESSION_DIR):
         self.storage_path = storage_path
 
+    # ------------------------------------------------------------------
     def _session_path(self, session_id: str) -> Path:
         return self.storage_path / f"{session_id}.json"
 
-    def save(self, session: ChatSession):
+    # ------------------------------------------------------------------
+    def save(self, session: ChatSession) -> None:
+        """Serialize ``session`` to disk."""
+
         with open(self._session_path(session.session_id), "w", encoding="utf-8") as f:
             json.dump(session.to_dict(), f, indent=2)
 
+    # ------------------------------------------------------------------
     def load(self, session_id: str) -> Optional[ChatSession]:
+        """Load a session by identifier."""
+
         path = self._session_path(session_id)
         if not path.exists():
             return None
         try:
             with open(path, "r", encoding="utf-8") as f:
                 data = json.load(f)
-                return ChatSession.from_dict(data)
+            return ChatSession.from_dict(data)
         except json.JSONDecodeError:
-            print(f"⚠️ Corrupt session file for {session_id}, deleting.")
+            logger.warning("Corrupt session file for %s, deleting.", session_id)
             path.unlink()
             return None
 
+    # ------------------------------------------------------------------
     def list_sessions(self) -> List[Dict]:
         return [
             {
                 "id": f.stem,
                 "path": str(f),
-                "modified": f.stat().st_mtime
+                "modified": f.stat().st_mtime,
             }
             for f in self.storage_path.glob("*.json")
         ]
 
-    def delete(self, session_id: str):
+    # ------------------------------------------------------------------
+    def delete(self, session_id: str) -> None:
         path = self._session_path(session_id)
         if path.exists():
             path.unlink()
 
+    # ------------------------------------------------------------------
     def exists(self, session_id: str) -> bool:
         return self._session_path(session_id).exists()


### PR DESCRIPTION
## Summary
- Introduce dataclass-based `ChatExchange` and `ChatSession` with helper methods for trimming history and serialization
- Add centralized logger utility and apply structured logging to session storage and chat route
- Simplify chat route logic and correct bug that discarded conversation history

## Testing
- `python -m py_compile app/routes/api_chat_search.py utility/chat_state.py utility/db_manager.py utility/llm_prompt_engine.py utility/session_store.py utility/logger.py`

------
https://chatgpt.com/codex/tasks/task_e_6890aafb27ac832cb1222171511c3370