### PR TITLE
Fix document toggle ID reference

### DIFF
--- a/app/static/js/documents.js
+++ b/app/static/js/documents.js
@@ -93,14 +93,14 @@ function renderDocumentList(docs, filter = "") {
     toggleBtn.textContent = "Deactivate";
 
     initToggleState(doc.id, true);
-    const current = !getInactiveSources().includes(source);
+    const current = !getInactiveSources().includes(doc.id);
     statusSpan.textContent = current ? "Active" : "Inactive";
     toggleBtn.textContent = current ? "Deactivate" : "Activate";
 
     toggleBtn.classList.toggle("btn-active", current);
     toggleBtn.classList.toggle("btn-inactive", !current);
     toggleBtn.addEventListener("click", () => {
-      const current = !getInactiveSources().includes(source);
+      const current = !getInactiveSources().includes(doc.id);
       const next = !current;
       toggleSource(doc.id, !current);
 


### PR DESCRIPTION
## Summary
- ensure document list toggles track each document by its `id`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6892bb49d954832cab8b016a09bc47d1