### PR TITLE
Add new chat session endpoint and frontend controls

### DIFF
--- a/app/routes/api_chat_search.py
+++ b/app/routes/api_chat_search.py
@@ -46,13 +46,13 @@ async def chat(
     message: str = Form(...),
     inactive: Optional[str] = Form(None),
     persona: str = Form(""),
-    user_id: str = Form(...),
+    session_id: str = Form(...),
     stream: bool = Form(False)
 ):
-    session = store.load(user_id)
+    session = store.load(session_id)
     if session is None:
-        logger.info("Creating new chat session for %s", user_id)
-        session = ChatSession.new(session_id=user_id)
+        logger.info("Creating new chat session for %s", session_id)
+        session = ChatSession.new(session_id=session_id)
         store.save(session)
 
     inactive_sources = set(json.loads(inactive)) if inactive else set()
@@ -60,7 +60,7 @@ async def chat(
         message, top_k=10 if stream else 5, exclude_sources=inactive_sources
     )
     context_blocks = filter_out_chunks(raw_blocks)
-    logger.info("User %s queried with %d context blocks", user_id, len(context_blocks))
+    logger.info("Session %s queried with %d context blocks", session_id, len(context_blocks))
     prompt = llm.build_prompt(
         summary=session.summary,
         history=session.history,
@@ -133,6 +133,6 @@ async def legacy_chat_stream(
     message: str = Form(...),
     inactive: Optional[str] = Form(None),
     persona: str = Form(""),
-    user_id: str = Form(...)
+    session_id: str = Form(...)
 ):
-    return await chat(message, inactive, persona, user_id, stream=True)
+    return await chat(message, inactive, persona, session_id, stream=True)

--- a/app/routes/api_sessions.py
+++ b/app/routes/api_sessions.py
@@ -64,3 +64,17 @@ async def get_or_create_session(request: Request):
     response = JSONResponse({"session_id": session.session_id})
     response.set_cookie(key=SESSION_COOKIE_NAME, value=session.session_id, httponly=False)
     return response
+
+
+@router.post("/session")
+async def create_session():
+    """Always create and return a new chat session."""
+
+    session = ChatSession.new()
+    store.save(session)
+
+    response = JSONResponse({"session_id": session.session_id})
+    response.set_cookie(
+        key=SESSION_COOKIE_NAME, value=session.session_id, httponly=False
+    )
+    return response

--- a/app/static/js/chat.js
+++ b/app/static/js/chat.js
@@ -2,6 +2,8 @@
 
 import { $, escapeHtml } from './dom.js';
 import { renderSearchResultsBlock } from './render.js';
+import { startNewSession } from './session.js';
+import { chatHistory } from './chatHistory.js';
 
 /**
  * Appends a chat message to the chat box.
@@ -42,6 +44,7 @@ export function initChat(session) {
   const resetLLMButton = $("reset-llm");
   const downloadButton = $("download-chat");
   const personaButton = $("open-persona-btn");
+  const newChatButton = $("new-chat");
 
   if (!chatForm || !chatInput || !submitButton) return;
 
@@ -87,7 +90,7 @@ export function initChat(session) {
         body: new URLSearchParams({
           message: msg,
           persona,
-          user_id: session.sessionId
+          session_id: session.sessionId
         })
       });
 
@@ -128,6 +131,15 @@ export function initChat(session) {
     chatInput.focus();
   });
 
+  // 🆕 START NEW CHAT SESSION
+  newChatButton?.addEventListener("click", async () => {
+    const newId = await startNewSession();
+    session.sessionId = newId;
+    resetChatUI();
+    chatHistory.init(session);
+    chatInput.focus();
+  });
+
   // 🧠 RESET MEMORY
   resetLLMButton?.addEventListener("click", async () => {
     resetChatUI();
@@ -136,7 +148,7 @@ export function initChat(session) {
     resetLLMButton.disabled = true;
 
     try {
-      await fetch(`/debug/memory?user_id=${encodeURIComponent(session.sessionId)}`, {
+      await fetch(`/debug/memory?session_id=${encodeURIComponent(session.sessionId)}`, {
         method: "DELETE"
       });
       appendMessage("Assistant", "Memory has been cleared.");

--- a/app/static/js/session.js
+++ b/app/static/js/session.js
@@ -53,6 +53,17 @@ export async function ensureSession() {
   return sessionId;
 }
 
+export async function startNewSession() {
+  const res = await fetch("/session", { method: "POST" });
+  const data = await res.json();
+  const sessionId = data.session_id;
+  setCookie(SESSION_COOKIE_NAME, sessionId);
+  appState.sessionId = sessionId;
+  appState.inactiveSources = [];
+  updateSessionStorage();
+  return sessionId;
+}
+
 export function getSessionId() {
   return appState.sessionId;
 }

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -94,6 +94,7 @@
 
           <div style="display: flex; align-items: center; gap: 1em; margin-bottom: 1em;">
             <button id="open-persona-btn">Edit Persona</button>
+            <button id="new-chat" type="button">New Chat</button>
             <button id="clear-history" type="button">Clear Logs</button>
             <button id="reset-llm" type="button">Reset LLM</button>
             <button id="download-chat">Download Chat</button>


### PR DESCRIPTION
## Summary
- add POST /session to always start a fresh chat session
- wire frontend to request new session IDs and expose a New Chat button
- rename user_id param to session_id for chat requests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892bb4be5f8832c839b9acaf2e2a0cf