### PR TITLE
Fix chat session handling and allow new sessions

### DIFF
--- a/app/static/js/chat.js
+++ b/app/static/js/chat.js
@@ -48,11 +48,19 @@ export function initChat(session) {
 
   if (!chatForm || !chatInput || !submitButton) return;
 
+  resetChatUI();
+
   // 🔁 CHAT SUBMISSION
   chatForm.addEventListener("submit", async (e) => {
     e.preventDefault();
     const msg = chatInput.value.trim();
     if (!msg) return;
+
+    if (!session.sessionId) {
+      const newId = await startNewSession();
+      session.sessionId = newId;
+      chatHistory.init(session);
+    }
 
     // Disable UI
     chatInput.disabled = true;

--- a/app/static/js/chatHistory.js
+++ b/app/static/js/chatHistory.js
@@ -1,7 +1,7 @@
 // chatHistory.js
 
 import { $ } from './dom.js';
-import { ensureSession } from './session.js';
+import { setSessionId } from './session.js';
 
 /**
  * Clears the chat UI.
@@ -44,7 +44,6 @@ async function loadSessionMessages(sessionId) {
     const history = data.history;
 
     clearChatBox();
-    await ensureSession();
 
     for (const [user, assistant] of history) {
       renderMessagePair(user, assistant);
@@ -89,6 +88,8 @@ export const chatHistory = {
           `;
           div.addEventListener("click", () => {
             console.log("📦 Loading session:", sessionEntry.session_id);
+            setSessionId(sessionEntry.session_id);
+            session.sessionId = sessionEntry.session_id;
             loadSessionMessages(sessionEntry.session_id);
           });
           container.appendChild(div);

--- a/app/static/js/session.js
+++ b/app/static/js/session.js
@@ -11,6 +11,10 @@ export function setCookie(name, value, days = 30) {
   document.cookie = `${name}=${encodeURIComponent(value)}; expires=${expires}; path=/; SameSite=Lax`;
 }
 
+export function clearCookie(name) {
+  document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
+}
+
 // --- App State ---
 let appState = {
   sessionId: null,
@@ -34,20 +38,13 @@ function loadSessionStorage() {
 }
 
 // --- Session Management ---
-export async function ensureSession() {
-  let sessionId = getCookie(SESSION_COOKIE_NAME);
 
-  if (!sessionId) {
-    console.log("🟡 No session cookie found — requesting new session...");
-    const res = await fetch("/session");
-    const data = await res.json();
-    sessionId = data.session_id;
+export function setSessionId(sessionId) {
+  if (sessionId) {
     setCookie(SESSION_COOKIE_NAME, sessionId);
-    console.log("🟢 New session ID set:", sessionId);
   } else {
-    console.log("✅ Using existing session:", sessionId);
+    clearCookie(SESSION_COOKIE_NAME);
   }
-
   appState.sessionId = sessionId;
   updateSessionStorage();
   return sessionId;
@@ -57,10 +54,8 @@ export async function startNewSession() {
   const res = await fetch("/session", { method: "POST" });
   const data = await res.json();
   const sessionId = data.session_id;
-  setCookie(SESSION_COOKIE_NAME, sessionId);
-  appState.sessionId = sessionId;
+  setSessionId(sessionId);
   appState.inactiveSources = [];
-  updateSessionStorage();
   return sessionId;
 }
 
@@ -74,7 +69,8 @@ export function getSessionState() {
 
 export async function initAppState() {
   loadSessionStorage();
-  appState.sessionId = await ensureSession();
+  clearCookie(SESSION_COOKIE_NAME);
+  appState.sessionId = null;
   updateSessionStorage();
 }
 


### PR DESCRIPTION
## Summary
- reset session state on load and add helpers to set or clear session cookies
- switch active session when a chat history item is selected
- start a new session automatically when chatting on a blank page

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6892bf8b6d78832c9cbfe3763b02d92e