### PR TITLE
Add Codex guidance and JS sandbox for isolated testing

### DIFF
--- a/.codexignore
+++ b/.codexignore
@@ -1,0 +1,14 @@
+# .codexignore
+
+# Ignore heavy backend directories
+app/embedding/
+app/vector/
+scripts/
+node_modules/
+venv/
+
+# Don't trigger full environment loads unless explicitly needed
+requirements.txt
+*.onnx
+*.pt
+*.bin

--- a/README.md
+++ b/README.md
@@ -90,3 +90,11 @@ Deployable-Knowledge is an offline-capable Retrieval-Augmented Generation (RAG) 
    different chat model than the default `mistral:7b`.
 
 5. Navigate to `http://localhost:8000` in your browser.
+
+---
+
+## Codex Usage Guidance
+
+- Do **not** start or load the backend when editing JavaScript files. Work on the file directly.
+- Ignore heavy backend directories such as `app/embedding/`, `app/vector/`, `scripts/`, `node_modules/`, and `venv/`.
+- Keep edits sandboxed. Do not run tests or the backend unless explicitly instructed.

--- a/app/static/js/chat.js
+++ b/app/static/js/chat.js
@@ -1,3 +1,4 @@
+// Codex: Do NOT load backend or Python files. This file is frontend-only.
 // chat.js
 
 import { $, escapeHtml } from './dom.js';

--- a/app/static/js/chatHistory.js
+++ b/app/static/js/chatHistory.js
@@ -1,3 +1,4 @@
+// Codex: Do NOT load backend or Python files. This file is frontend-only.
 // chatHistory.js
 
 import { $ } from './dom.js';

--- a/app/static/js/documents.js
+++ b/app/static/js/documents.js
@@ -1,3 +1,4 @@
+// Codex: Do NOT load backend or Python files. This file is frontend-only.
 // documents.js — handles document list, toggles, filters, removal
 
 import { $, escapeHtml, showConfirmation } from './dom.js';

--- a/app/static/js/dom.js
+++ b/app/static/js/dom.js
@@ -1,3 +1,4 @@
+// Codex: Do NOT load backend or Python files. This file is frontend-only.
 // dom.js — shared DOM helpers and modal logic
 
 /**

--- a/app/static/js/download.js
+++ b/app/static/js/download.js
@@ -1,3 +1,4 @@
+// Codex: Do NOT load backend or Python files. This file is frontend-only.
 // download.js
 
 import { $ } from './dom.js';

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -1,3 +1,4 @@
+// Codex: Do NOT load backend or Python files. This file is frontend-only.
 import { initAppState, getSessionState } from './session.js';
 import { initChat } from './chat.js';
 import { chatHistory } from './chatHistory.js';

--- a/app/static/js/persona_editor.js
+++ b/app/static/js/persona_editor.js
@@ -1,3 +1,4 @@
+// Codex: Do NOT load backend or Python files. This file is frontend-only.
 // persona_editor.js
 import { $ } from './dom.js';
 

--- a/app/static/js/render.js
+++ b/app/static/js/render.js
@@ -1,3 +1,4 @@
+// Codex: Do NOT load backend or Python files. This file is frontend-only.
 import { escapeHtml } from './dom.js';
 import { initToggleState, toggleSource, getInactiveSources } from "./session.js";
 

--- a/app/static/js/search.js
+++ b/app/static/js/search.js
@@ -1,3 +1,4 @@
+// Codex: Do NOT load backend or Python files. This file is frontend-only.
 // search.js — handles semantic search bar and results rendering
 
 import { $, escapeHtml } from './dom.js';

--- a/app/static/js/session.js
+++ b/app/static/js/session.js
@@ -1,3 +1,4 @@
+// Codex: Do NOT load backend or Python files. This file is frontend-only.
 const SESSION_COOKIE_NAME = "chat_session_id";
 
 // --- Cookies ---

--- a/app/static/js/upload.js
+++ b/app/static/js/upload.js
@@ -1,3 +1,4 @@
+// Codex: Do NOT load backend or Python files. This file is frontend-only.
 import { $, escapeHtml } from './dom.js';
 import { initDocuments } from './documents.js'; // to refresh doc list
 

--- a/app/static/js/uploadChat.js
+++ b/app/static/js/uploadChat.js
@@ -1,3 +1,4 @@
+// Codex: Do NOT load backend or Python files. This file is frontend-only.
 // uploadChat.js
 import { $ } from './dom.js';
 

--- a/sandbox-js/README.md
+++ b/sandbox-js/README.md
@@ -1,0 +1,4 @@
+# sandbox-js
+
+Local JavaScript-only experiments. No backend or server logic.
+Load `session_test.html` in a browser to run `test_main.js`.

--- a/sandbox-js/session_test.html
+++ b/sandbox-js/session_test.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Sandbox JS Test</title>
+</head>
+<body>
+  <script src="test_main.js"></script>
+</body>
+</html>

--- a/sandbox-js/test_main.js
+++ b/sandbox-js/test_main.js
@@ -1,0 +1,3 @@
+// Codex: Do NOT load backend or Python files. This file is frontend-only.
+
+console.log('sandbox test');

--- a/sandbox/session_debug/README.md
+++ b/sandbox/session_debug/README.md
@@ -1,0 +1,19 @@
+# Session Debug Sandbox
+
+This directory contains a minimal, self-contained environment for experimenting
+with session logic **without** involving the project's FastAPI routes, frontend
+JavaScript, or NLP components. The goal is to isolate and validate session ID
+handling before integrating it back into the full application.
+
+## Contents
+- `session_state.py` – simple setters/getters for a session ID.
+- `session_test.py` – small test suite that exercises the session state.
+
+## Usage
+Run the tests directly with Python:
+
+```bash
+python session_test.py
+```
+
+No third‑party packages or frameworks are required for this sandbox.

--- a/sandbox/session_debug/session_state.py
+++ b/sandbox/session_debug/session_state.py
@@ -1,0 +1,40 @@
+"""Simple session state management for sandbox testing.
+
+This module uses module-level state to simulate the session ID behavior of a
+larger application. It intentionally avoids any external dependencies or
+frameworks so that the logic can be debugged in isolation.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+# Internal storage for the current session ID.  The value is ``None`` until a
+# session is explicitly started or set.
+_session_id: str | None = None
+
+def setSessionId(session_id: str) -> None:
+    """Explicitly set the active session ID.
+
+    Parameters
+    ----------
+    session_id:
+        The identifier to mark as the current session.
+    """
+    global _session_id
+    _session_id = session_id
+
+def getSessionId() -> str | None:
+    """Return the current session ID if one has been set."""
+    return _session_id
+
+def startNewSession() -> str:
+    """Start a new session and return its identifier.
+
+    The new ID is generated using :func:`uuid.uuid4` from Python's standard
+    library.  In the real application this might trigger more complex startup
+    logic, but for debugging purposes we only store and return the new ID.
+    """
+    global _session_id
+    _session_id = str(uuid.uuid4())
+    return _session_id

--- a/sandbox/session_debug/session_test.py
+++ b/sandbox/session_debug/session_test.py
@@ -1,0 +1,28 @@
+"""Tests for the lightweight session state module.
+
+These tests intentionally avoid any external frameworks or dependencies to
+keep the sandbox self‑contained. Run them with ``python session_test.py``.
+"""
+
+from __future__ import annotations
+
+import session_state
+
+
+def test_set_and_get_session_id():
+    session_state.setSessionId("initial")
+    assert session_state.getSessionId() == "initial"
+
+
+def test_start_new_session():
+    session_state.setSessionId("old")
+    first = session_state.getSessionId()
+    new = session_state.startNewSession()
+    assert new != first, "startNewSession should generate a new ID"
+    assert session_state.getSessionId() == new
+
+
+if __name__ == "__main__":  # pragma: no cover - manual test runner
+    test_set_and_get_session_id()
+    test_start_new_session()
+    print("All session_state tests passed.")


### PR DESCRIPTION
## Summary
- document Codex usage guidance to avoid loading backend when editing JavaScript
- add `.codexignore` and standalone `sandbox-js` folder for frontend-only experiments
- mark frontend scripts with a directive comment to keep Codex from touching backend files

## Testing
- `python sandbox/session_debug/session_test.py`
- `pytest sandbox/session_debug`


------
https://chatgpt.com/codex/tasks/task_e_6892d7f45090832ca535d7a266fa92fb