### PR TITLE
refactor: consolidate rendering and panel toggles

### DIFF
--- a/app/static/js/chat.js
+++ b/app/static/js/chat.js
@@ -2,34 +2,11 @@
 // chat.js
 
 import { $, escapeHtml } from './dom.js';
-import { renderSearchResultsBlock } from './render.js';
+import { renderSearchResultsBlock, renderChatMessage, clearChatUI } from './render.js';
 import { startNewSession } from './session.js';
 import { chatHistory } from './chatHistory.js';
 
-/**
- * Appends a chat message to the chat box.
- * @param {string} role - 'You' or 'Assistant'
- * @param {string} text - Text to display
- */
-function appendMessage(role, text) {
-  const chatBox = $("chat-box");
-  if (!chatBox) return;
-
-  const msgDiv = document.createElement("div");
-  msgDiv.innerHTML = `<strong>${role}:</strong> ${escapeHtml(text)}`;
-  chatBox.appendChild(msgDiv);
-  chatBox.scrollTop = chatBox.scrollHeight;
-}
-
-/**
- * Clears the chat box entirely.
- */
-function resetChatUI() {
-  const chatBox = $("chat-box");
-  if (chatBox) chatBox.innerHTML = '';
-  const searchResults = $("search-results");
-  if (searchResults) searchResults.innerHTML = '';
-}
+// Rendering helpers moved to render.js
 
 /**
  * Initializes the chat functionality.
@@ -49,7 +26,7 @@ export function initChat(session) {
 
   if (!chatForm || !chatInput || !submitButton) return;
 
-  resetChatUI();
+  clearChatUI();
 
   // 🔁 CHAT SUBMISSION
   chatForm.addEventListener("submit", async (e) => {
@@ -70,7 +47,7 @@ export function initChat(session) {
     clearButton.disabled = true;
     submitButton.textContent = "Loading...";
 
-    appendMessage("You", msg);
+    renderChatMessage("You", msg);
     chatInput.value = "";
 
     const botMsg = document.createElement("div");
@@ -136,7 +113,7 @@ export function initChat(session) {
 
   // 🧼 CLEAR CHAT
   clearButton?.addEventListener("click", () => {
-    resetChatUI();
+    clearChatUI();
     chatInput.focus();
   });
 
@@ -144,14 +121,14 @@ export function initChat(session) {
   newChatButton?.addEventListener("click", async () => {
     const newId = await startNewSession();
     session.sessionId = newId;
-    resetChatUI();
+    clearChatUI();
     chatHistory.init(session);
     chatInput.focus();
   });
 
   // 🧠 RESET MEMORY
   resetLLMButton?.addEventListener("click", async () => {
-    resetChatUI();
+    clearChatUI();
     chatInput.disabled = true;
     submitButton.disabled = true;
     resetLLMButton.disabled = true;
@@ -160,9 +137,9 @@ export function initChat(session) {
       await fetch(`/debug/memory?session_id=${encodeURIComponent(session.sessionId)}`, {
         method: "DELETE"
       });
-      appendMessage("Assistant", "Memory has been cleared.");
+      renderChatMessage("Assistant", "Memory has been cleared.");
     } catch (err) {
-      appendMessage("Assistant", `Error resetting memory: ${escapeHtml(err.message || err)}`);
+      renderChatMessage("Assistant", `Error resetting memory: ${escapeHtml(err.message || err)}`);
     }
 
     chatInput.disabled = false;

--- a/app/static/js/chatHistory.js
+++ b/app/static/js/chatHistory.js
@@ -3,34 +3,7 @@
 
 import { $ } from './dom.js';
 import { setSessionId } from './session.js';
-
-/**
- * Clears the chat UI.
- */
-function clearChatBox() {
-  const chatBox = $("chat-box");
-  if (chatBox) chatBox.innerHTML = '';
-  const searchResults = $("search-results");
-  if (searchResults) searchResults.innerHTML = '';
-}
-
-/**
- * Renders a single message pair to the chat box.
- * @param {string} userText 
- * @param {string} assistantText 
- */
-function renderMessagePair(userText, assistantText) {
-  const chatBox = $("chat-box");
-  if (!chatBox) return;
-
-  const userDiv = document.createElement("div");
-  userDiv.innerHTML = `<strong>You:</strong> ${userText}`;
-  chatBox.appendChild(userDiv);
-
-  const botDiv = document.createElement("div");
-  botDiv.innerHTML = `<strong>Assistant:</strong> ${assistantText}`;
-  chatBox.appendChild(botDiv);
-}
+import { renderMessagePair, clearChatUI } from './render.js';
 
 /**
  * Loads and displays messages for a specific session.
@@ -44,14 +17,14 @@ async function loadSessionMessages(sessionId) {
     const data = await res.json();
     const history = data.history;
 
-    clearChatBox();
+    clearChatUI();
 
     for (const [user, assistant] of history) {
       renderMessagePair(user, assistant);
     }
   } catch (err) {
     console.error("❌ Error loading session messages:", err);
-    clearChatBox();
+    clearChatUI();
     renderMessagePair("System", `⚠️ Failed to load session history: ${err.message}`);
   }
 }

--- a/app/static/js/documents.js
+++ b/app/static/js/documents.js
@@ -1,8 +1,8 @@
 // Codex: Do NOT load backend or Python files. This file is frontend-only.
 // documents.js — handles document list, toggles, filters, removal
 
-import { $, escapeHtml, showConfirmation } from './dom.js';
-import { toggleSource , getInactiveSources, initToggleState } from './session.js';
+import { $, escapeHtml, initPanelToggle } from './dom.js';
+import { renderDocumentList } from './render.js';
 
 
 let allDocs = [];
@@ -14,15 +14,7 @@ let allDocs = [];
 export function initDocuments() {
   fetchDocuments();
   setupFilterForm();
-
-  const btn = $("toggle-docs-btn");
-  const wrapper = $("doc-panel-wrapper");
-  if (btn && wrapper) {
-    btn.addEventListener("click", () => {
-      wrapper.classList.toggle("collapsed");
-      btn.textContent = wrapper.classList.contains("collapsed") ? "»" : "«";
-    });
-  }
+  initPanelToggle('doc-panel-wrapper', 'toggle-docs-btn');
 }
 
 /**
@@ -34,7 +26,7 @@ function fetchDocuments() {
     .then(res => res.json())
     .then(docs => {
       allDocs = docs;
-      renderDocumentList(allDocs);
+      renderDocumentList(allDocs, '', { refresh: fetchDocuments });
     })
     .catch(err => {
       const list = $("document-list");
@@ -55,7 +47,7 @@ function setupFilterForm() {
 
   form.addEventListener("submit", e => {
     e.preventDefault();
-    renderDocumentList(allDocs, input.value.trim());
+    renderDocumentList(allDocs, input.value.trim(), { refresh: fetchDocuments });
   });
 }
 
@@ -65,97 +57,3 @@ function setupFilterForm() {
  * @param {*} filter 
  * @returns 
  */
-function renderDocumentList(docs, filter = "") {
-  const list = $("document-list");
-  if (!list) return;
-
-  list.innerHTML = ""; // Clear list
-
-  const filtered = docs.filter(doc =>
-    doc.title.toLowerCase().includes(filter.toLowerCase())
-  );
-
-  if (filtered.length === 0) {
-    list.innerHTML = "<li><em>No results found.</em></li>";
-    return;
-  }
-
-  filtered.forEach(doc => {
-    const li = document.createElement("li");
-    li.setAttribute("data-doc-id", doc.id);
-    li.setAttribute("data-active", "true");
-
-    const statusSpan = document.createElement("span");
-    statusSpan.className = "status-label";
-    statusSpan.textContent = "Active";
-
-    const toggleBtn = document.createElement("button");
-    toggleBtn.className = "toggle-btn btn-active";
-    toggleBtn.textContent = "Deactivate";
-
-    initToggleState(doc.id, true);
-    const current = !getInactiveSources().includes(doc.id);
-    statusSpan.textContent = current ? "Active" : "Inactive";
-    toggleBtn.textContent = current ? "Deactivate" : "Activate";
-
-    toggleBtn.classList.toggle("btn-active", current);
-    toggleBtn.classList.toggle("btn-inactive", !current);
-    toggleBtn.addEventListener("click", () => {
-      const current = !getInactiveSources().includes(doc.id);
-      const next = !current;
-      toggleSource(doc.id, !current);
-
-      statusSpan.textContent = current ? "Inactive" : "Active";
-      toggleBtn.textContent = current ? "Activate" : "Deactivate";
-
-      toggleBtn.classList.toggle("btn-active", next);
-      toggleBtn.classList.toggle("btn-inactive", !next);
-    });
-
-    const removeBtn = document.createElement("button");
-    removeBtn.textContent = "Remove";
-    removeBtn.style.marginLeft = "0.5rem";
-    removeBtn.addEventListener("click", () => {
-      showConfirmation(`Remove document "${doc.title}"?`).then(confirmed => {
-        if (!confirmed) return;
-
-        fetch("/remove", {
-          method: "POST",
-          headers: { "Content-Type": "application/x-www-form-urlencoded" },
-          body: new URLSearchParams({ source: doc.id })
-        })
-          .then(res => res.json())
-          .then(data => {
-            if (data.status === "success") fetchDocuments();
-            else alert(`Error: ${data.message}`);
-          })
-          .catch(err => alert(`Failed to remove: ${err.message || err}`));
-      });
-    });
-
-    li.innerHTML = `
-      <strong title="${escapeHtml(doc.title)}">${escapeHtml(doc.title)}</strong><br />
-      <small>Segments: ${doc.segments}</small><br />
-      <small>Status: </small>
-    `;
-    li.appendChild(statusSpan);
-    li.appendChild(document.createElement("br"));
-    li.appendChild(toggleBtn);
-    li.appendChild(removeBtn);
-    list.appendChild(li);
-  });
-}
-
-export function loadActiveDocuments(docs) {
-  const docPanel = document.getElementById("document-panel");
-  if (!docPanel) return;
-
-  // Clear and reload content
-  docPanel.innerHTML = "";
-  docs.forEach(doc => {
-    const div = document.createElement("div");
-    div.className = "document-entry";
-    div.innerHTML = `<strong>${doc.name || "Untitled"}</strong><br/><small>${doc.source || "Unknown"}</small>`;
-    docPanel.appendChild(div);
-  });
-}

--- a/app/static/js/dom.js
+++ b/app/static/js/dom.js
@@ -52,3 +52,24 @@ export function showConfirmation(message) {
     no.addEventListener("click", noHandler);
   });
 }
+
+/**
+ * Initializes a toggle button that collapses/expands a panel.
+ * @param {string} wrapperId - ID of the wrapper element.
+ * @param {string} buttonId - ID of the toggle button.
+ * @param {Object} [options]
+ * @param {string} [options.collapsedText="»"] - Text when panel is collapsed.
+ * @param {string} [options.expandedText="«"] - Text when panel is expanded.
+ */
+export function initPanelToggle(wrapperId, buttonId, { collapsedText = "»", expandedText = "«" } = {}) {
+  const wrapper = $(wrapperId);
+  const button = $(buttonId);
+  if (!wrapper || !button) return;
+
+  button.addEventListener("click", () => {
+    const isCollapsed = wrapper.classList.toggle("collapsed");
+    if (button.textContent !== undefined) {
+      button.textContent = isCollapsed ? collapsedText : expandedText;
+    }
+  });
+}

--- a/app/static/js/render.js
+++ b/app/static/js/render.js
@@ -1,5 +1,5 @@
 // Codex: Do NOT load backend or Python files. This file is frontend-only.
-import { escapeHtml } from './dom.js';
+import { $, escapeHtml, showConfirmation } from './dom.js';
 import { initToggleState, toggleSource, getInactiveSources } from "./session.js";
 
 /**
@@ -51,4 +51,139 @@ export function renderSearchResultsBlock(results, { filterInactive = true } = {}
     `;
     })
     .join('');
+}
+
+/**
+ * Renders a single chat message into the chat box.
+ * @param {string} role
+ * @param {string} text
+ */
+export function renderChatMessage(role, text) {
+  const chatBox = $("chat-box");
+  if (!chatBox) return;
+  const msgDiv = document.createElement("div");
+  msgDiv.innerHTML = `<strong>${escapeHtml(role)}:</strong> ${escapeHtml(text)}`;
+  chatBox.appendChild(msgDiv);
+  chatBox.scrollTop = chatBox.scrollHeight;
+}
+
+/**
+ * Renders a pair of user/assistant messages.
+ * @param {string} userText
+ * @param {string} assistantText
+ */
+export function renderMessagePair(userText, assistantText) {
+  renderChatMessage("You", userText);
+  renderChatMessage("Assistant", assistantText);
+}
+
+/**
+ * Clears the chat box and search results.
+ */
+export function clearChatUI() {
+  const chatBox = $("chat-box");
+  if (chatBox) chatBox.innerHTML = '';
+  const searchResults = $("search-results");
+  if (searchResults) searchResults.innerHTML = '';
+}
+
+/**
+ * Renders the document list with optional filtering.
+ * @param {Array} docs
+ * @param {string} [filter=""]
+ */
+export function renderDocumentList(docs, filter = "", { refresh } = {}) {
+  const list = $("document-list");
+  if (!list) return;
+
+  list.innerHTML = "";
+
+  const filtered = docs.filter(doc =>
+    doc.title.toLowerCase().includes(filter.toLowerCase())
+  );
+
+  if (filtered.length === 0) {
+    list.innerHTML = "<li><em>No results found.</em></li>";
+    return;
+  }
+
+  filtered.forEach(doc => {
+    const li = document.createElement("li");
+    li.setAttribute("data-doc-id", doc.id);
+    li.setAttribute("data-active", "true");
+
+    const statusSpan = document.createElement("span");
+    statusSpan.className = "status-label";
+    statusSpan.textContent = "Active";
+
+    const toggleBtn = document.createElement("button");
+    toggleBtn.className = "toggle-btn btn-active";
+    toggleBtn.textContent = "Deactivate";
+
+    initToggleState(doc.id, true);
+    const current = !getInactiveSources().includes(doc.id);
+    statusSpan.textContent = current ? "Active" : "Inactive";
+    toggleBtn.textContent = current ? "Deactivate" : "Activate";
+    toggleBtn.classList.toggle("btn-active", current);
+    toggleBtn.classList.toggle("btn-inactive", !current);
+    toggleBtn.addEventListener("click", () => {
+      const current = !getInactiveSources().includes(doc.id);
+      const next = !current;
+      toggleSource(doc.id, !current);
+      statusSpan.textContent = current ? "Inactive" : "Active";
+      toggleBtn.textContent = current ? "Activate" : "Deactivate";
+      toggleBtn.classList.toggle("btn-active", next);
+      toggleBtn.classList.toggle("btn-inactive", !next);
+    });
+
+    const removeBtn = document.createElement("button");
+    removeBtn.textContent = "Remove";
+    removeBtn.style.marginLeft = "0.5rem";
+    removeBtn.addEventListener("click", () => {
+      showConfirmation(`Remove document "${doc.title}"?`).then(confirmed => {
+        if (!confirmed) return;
+        fetch("/remove", {
+          method: "POST",
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+          body: new URLSearchParams({ source: doc.id })
+        })
+          .then(res => res.json())
+          .then(data => {
+            if (data.status === "success") {
+              refresh?.();
+            } else {
+              alert(`Error: ${data.message}`);
+            }
+          })
+          .catch(err => alert(`Failed to remove: ${err.message || err}`));
+      });
+    });
+
+    li.innerHTML = `
+      <strong title="${escapeHtml(doc.title)}">${escapeHtml(doc.title)}</strong><br />
+      <small>Segments: ${doc.segments}</small><br />
+      <small>Status: </small>
+    `;
+    li.appendChild(statusSpan);
+    li.appendChild(document.createElement("br"));
+    li.appendChild(toggleBtn);
+    li.appendChild(removeBtn);
+    list.appendChild(li);
+  });
+}
+
+/**
+ * Loads active documents into the document panel.
+ * @param {Array} docs
+ */
+export function loadActiveDocuments(docs) {
+  const docPanel = $("document-panel");
+  if (!docPanel) return;
+  docPanel.innerHTML = "";
+  docs.forEach(doc => {
+    const div = document.createElement("div");
+    div.className = "document-entry";
+    div.innerHTML = `<strong>${escapeHtml(doc.name || "Untitled")}</strong><br/><small>${escapeHtml(doc.source || "Unknown")}</small>`;
+    docPanel.appendChild(div);
+  });
 }

--- a/app/static/js/search.js
+++ b/app/static/js/search.js
@@ -1,7 +1,7 @@
 // Codex: Do NOT load backend or Python files. This file is frontend-only.
 // search.js — handles semantic search bar and results rendering
 
-import { $, escapeHtml } from './dom.js';
+import { $, escapeHtml, initPanelToggle } from './dom.js';
 import { renderSearchResultsBlock } from './render.js';
 
 /**
@@ -16,12 +16,7 @@ export function initSearch() {
 
   if (!searchForm || !searchInput || !searchResults || !topKInput) return;
 
-    const docWrapper = document.getElementById("search-panel-wrapper");
-    const toggleBtn = document.getElementById("toggle-search-btn");
-
-    toggleBtn?.addEventListener("click", () => {
-    docWrapper.classList.toggle("collapsed");
-    });
+    initPanelToggle('search-panel-wrapper', 'toggle-search-btn');
 
   searchForm.addEventListener("submit", function (e) {
     e.preventDefault();


### PR DESCRIPTION
## Summary
- centralize chat message rendering and chat clearing helpers
- move document list rendering to shared module and add panel toggle utility
- standardize DOM lookups via `$` helper

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689327adebd0832cabff7395676d0c15