### PR TITLE
Harden file uploads and session handling

### DIFF
--- a/app/static/js/chat.js
+++ b/app/static/js/chat.js
@@ -72,14 +72,15 @@ export function initChat(session) {
     // 🤖 LLM RESPONSE
     try {
       const persona = $("persona-text")?.value || "";
+      const params = new URLSearchParams();
+      params.set("message", msg);
+      params.set("persona", persona);
+      params.set("session_id", session.sessionId);
+
       const response = await fetch("/chat-stream", {
         method: "POST",
         headers: { "Content-Type": "application/x-www-form-urlencoded" },
-        body: new URLSearchParams({
-          message: msg,
-          persona,
-          session_id: session.sessionId
-        })
+        body: params.toString()
       });
 
       if (!response.body) {

--- a/config.py
+++ b/config.py
@@ -19,6 +19,11 @@ LOCAL_MODEL_PATH = MODEL_DIR
 DEFAULT_CHUNKING_METHOD = "graph-pagerank"
 CHUNKING_METHOD_OPTIONS = ["sentences", "semantics", "graph", "paragraphs", "dynamic", "graph-pagerank"]
 
+# === Security ===
+ALLOWED_DOCUMENT_EXTENSIONS = {".txt", ".pdf", ".md", ".html"}
+MIN_TOP_K = 1
+MAX_TOP_K = 20
+
 # === Ollama ===
 OLLAMA_URL = os.getenv("OLLAMA_URL", "http://localhost:11434/api/generate")
 OLLAMA_MODEL = os.getenv("OLLAMA_MODEL", "mistral:7b")

--- a/utility/chat_state.py
+++ b/utility/chat_state.py
@@ -61,6 +61,7 @@ class ChatSession:
     """Container for a user's ongoing chat session."""
 
     session_id: str
+    user_id: str = "default"
     history: List[ChatExchange] = field(default_factory=list)
     summary: str = ""
     inactive_sources: List[str] = field(default_factory=list)
@@ -70,10 +71,10 @@ class ChatSession:
     # Construction helpers
     # ------------------------------------------------------------------
     @classmethod
-    def new(cls, session_id: Optional[str] = None) -> "ChatSession":
+    def new(cls, session_id: Optional[str] = None, user_id: str = "default") -> "ChatSession":
         """Create a new chat session with a random identifier."""
 
-        return cls(session_id=session_id or str(uuid.uuid4()))
+        return cls(session_id=session_id or str(uuid.uuid4()), user_id=user_id)
 
     # ------------------------------------------------------------------
     # Mutation helpers
@@ -110,6 +111,7 @@ class ChatSession:
     def to_dict(self) -> Dict:
         return {
             "session_id": self.session_id,
+            "user_id": self.user_id,
             "summary": self.summary,
             "history": [exchange.to_dict() for exchange in self.history],
             "inactive_sources": self.inactive_sources,
@@ -120,6 +122,7 @@ class ChatSession:
     def from_dict(cls, data: Dict) -> "ChatSession":
         session = cls(
             session_id=data.get("session_id", ""),
+            user_id=data.get("user_id", "default"),
             summary=data.get("summary", ""),
             inactive_sources=data.get("inactive_sources", []),
             persona=data.get("persona"),

--- a/utility/validation.py
+++ b/utility/validation.py
@@ -1,0 +1,51 @@
+"""Input validation utilities for file uploads and session handling."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Iterable
+from uuid import UUID
+
+# Characters allowed in filenames. Anything else will be replaced with "_".
+_FILENAME_CLEAN_PATTERN = re.compile(r"[^A-Za-z0-9._-]")
+
+
+def sanitize_filename(filename: str, allowed_extensions: Iterable[str] | None = None) -> str:
+    """Return a safe filename stripped of path components.
+
+    Parameters
+    ----------
+    filename:
+        Raw filename provided by the client.
+    allowed_extensions:
+        Optional iterable of lowercase extensions (including the dot) that
+        the filename must match. If provided and the filename's extension is
+        not in the set, :class:`ValueError` is raised.
+    """
+    name = Path(filename).name  # drop any directory components
+    name = _FILENAME_CLEAN_PATTERN.sub("_", name)
+    if name in {"", ".", ".."}:
+        raise ValueError("Invalid filename")
+    if allowed_extensions is not None:
+        ext = Path(name).suffix.lower()
+        if ext not in {e.lower() for e in allowed_extensions}:
+            raise ValueError(f"Unsupported file type: {ext}")
+    return name
+
+
+def validate_session_id(session_id: str) -> str:
+    """Validate that ``session_id`` is a UUID4 string.
+
+    Raises ``ValueError`` if the session ID is malformed.
+    Returns the normalized string form if valid.
+    """
+    try:
+        return str(UUID(session_id, version=4))
+    except Exception as exc:  # pragma: no cover - defensive
+        raise ValueError("Invalid session id") from exc
+
+
+def clamp_int(value: int, minimum: int, maximum: int) -> int:
+    """Clamp ``value`` to the inclusive ``[minimum, maximum]`` range."""
+    return max(minimum, min(maximum, value))


### PR DESCRIPTION
## Summary
- centralize filename and session validation utilities
- sanitize document uploads and enforce allowed extensions
- validate session identifiers and issue HttpOnly session cookies
- bound query result size to safe limits
- send session IDs with chat requests to satisfy backend validation

## Testing
- `python -m py_compile config.py utility/validation.py utility/session_store.py utility/chat_state.py app/routes/api_file_ingest.py app/routes/api_sessions.py app/routes/api_chat_search.py app/routes/ui_routes.py`


------
https://chatgpt.com/codex/tasks/task_e_6893499e0a8c832cb038a628d8e85e4b