### PR TITLE
Allow online setup and add huggingface_hub dependency

### DIFF
--- a/makefile
+++ b/makefile
@@ -2,6 +2,7 @@
 export CHROMA_TELEMETRY_ENABLED=false
 export TRANSFORMERS_OFFLINE=1
 export HF_DATASETS_OFFLINE=1
+export HF_HUB_OFFLINE=1
 
 # === Config (override with: make VAR=...) ===
 VENV_NAME ?= venv
@@ -12,9 +13,13 @@ UVICORN   := $(VENV_NAME)/bin/uvicorn
 APP_MODULE?= app.main:app
 MODEL_ID  ?= sentence-transformers/all-MiniLM-L6-v2
 
+
 .PHONY: setup venv install fetch-model verify-offline run embed-dir clean
 
 # ---------- ONLINE SETUP ----------
+setup: export TRANSFORMERS_OFFLINE=0
+setup: export HF_DATASETS_OFFLINE=0
+setup: export HF_HUB_OFFLINE=0
 setup: venv install fetch-model
 
 venv:

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ Jinja2==3.1.6
 python-multipart
 httpx
 markdown2==2.5.3
+huggingface_hub==0.27.0


### PR DESCRIPTION
## Summary
- disable Hugging Face offline flags during `make setup` so models can be fetched
- include `huggingface_hub` in requirements for direct snapshot downloads

## Testing
- `make setup MODEL_ID=sentence-transformers/all-MiniLM-L6-v2` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_689871a324b4832caf1ea645548f834b