### PR TITLE
feat: surface API errors with toast

### DIFF
--- a/app/static/js/ui/api.js
+++ b/app/static/js/ui/api.js
@@ -19,6 +19,16 @@ async function ok(res) {
   return res;
 }
 
+export function handleApiError(e) {
+  console.error(e);
+  const msg = e?.message || "An unexpected error occurred";
+  if (typeof window !== "undefined" && window.toast) {
+    window.toast(msg);
+  } else {
+    alert(msg);
+  }
+}
+
 export async function getOrCreateChatSession() {
   try {
     const res = await fetch("/session", { method: "POST", headers: JSON_HEADERS, credentials: "same-origin" });

--- a/app/static/js/ui/controllers/chat.js
+++ b/app/static/js/ui/controllers/chat.js
@@ -59,6 +59,7 @@ export function initChatController() {
         bubble.innerHTML = md(res.response ?? "(no response)");
       } catch (e2) {
         bubble.innerHTML = `<em>Error:</em> ${e2.message}`;
+        api.handleApiError(e2);
       }
     }
   };

--- a/app/static/js/ui/controllers/search.js
+++ b/app/static/js/ui/controllers/search.js
@@ -10,15 +10,19 @@ export function initSearchController(winId="win_search") {
   const results = win.querySelector("#search_results");
 
   go.addEventListener("click", async () => {
-    const data = await api.searchDocuments(q.value, Number(k.value || 5));
-    results.innerHTML = "";
-    (data.results || []).forEach(r => {
-      const card = document.createElement("div");
-      card.className = "result-card";
-      card.innerHTML = `<div>${r.text}</div>
+    try {
+      const data = await api.searchDocuments(q.value, Number(k.value || 5));
+      results.innerHTML = "";
+      (data.results || []).forEach(r => {
+        const card = document.createElement("div");
+        card.className = "result-card";
+        card.innerHTML = `<div>${r.text}</div>
         <div class="result-meta"><span>Source: ${r.source}</span>
         <span>Score: ${Number(r.score).toFixed(3)} • Page: ${r.page ?? "?"}</span></div>`;
-      results.appendChild(card);
-    });
+        results.appendChild(card);
+      });
+    } catch (e) {
+      api.handleApiError(e);
+    }
   });
 }

--- a/app/static/js/ui/controllers/sessions.js
+++ b/app/static/js/ui/controllers/sessions.js
@@ -9,7 +9,10 @@ let selectedIdx = null;
 
 export async function initSessionsController(winId="win_sessions") {
   const comp = getComponent(winId, "session_list");
-  if (comp) comp.render(await api.listSessions());
+  if (comp) {
+    try { comp.render(await api.listSessions()); }
+    catch (e) { api.handleApiError(e); }
+  }
 
   bus.addEventListener("ui:list-select", async (ev) => {
     const { winId: srcWin, elementId, item, index } = ev.detail || {};
@@ -26,8 +29,12 @@ export async function initSessionsController(winId="win_sessions") {
 
     // load history
     Store.sessionId = item.session_id;
-    const data = await api.getSession(Store.sessionId);
-    const log = document.querySelector("#win_chat #chat_log");
-    if (log) renderChatLog(data.history || [], log);
+    try {
+      const data = await api.getSession(Store.sessionId);
+      const log = document.querySelector("#win_chat #chat_log");
+      if (log) renderChatLog(data.history || [], log);
+    } catch (e) {
+      api.handleApiError(e);
+    }
   });
 }


### PR DESCRIPTION
## Summary
- add `handleApiError` helper to surface API failures via toast
- use `handleApiError` across UI controllers to report API errors

## Testing
- `npm test` *(fails: package.json missing)*
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899d6bb14a4832cb4a4856ca9ff8c08