### PR TITLE
Use cached DOM selector helper in controllers

### DIFF
--- a/app/static/js/dom.js
+++ b/app/static/js/dom.js
@@ -1,0 +1,12 @@
+const cache = new Map();
+
+export function qs(selector) {
+  if (cache.has(selector)) {
+    return cache.get(selector);
+  }
+  const el = document.querySelector(selector);
+  if (el) {
+    cache.set(selector, el);
+  }
+  return el;
+}

--- a/app/static/js/ui/controllers/chat.js
+++ b/app/static/js/ui/controllers/chat.js
@@ -2,13 +2,14 @@
 import * as api from "../api.js";
 import { Store } from "../store.js";
 import { md, escapeHtml } from "../render.js";
+import { qs } from "../../dom.js";
 
 export function initChatController() {
-  const chatWin = document.getElementById("win_chat");
+  const chatWin = qs("#win_chat");
   if (!chatWin) return;
-  const log = chatWin.querySelector("#chat_log");
-  const input = chatWin.querySelector("#chat_input");
-  const sendBtn = chatWin.querySelector(".chat-input .btn");
+  const log = qs("#win_chat #chat_log");
+  const input = qs("#win_chat #chat_input");
+  const sendBtn = qs("#win_chat .chat-input .btn");
 
   const pushUser = (text) => {
     const div = document.createElement("div");

--- a/app/static/js/ui/controllers/docs.js
+++ b/app/static/js/ui/controllers/docs.js
@@ -2,6 +2,7 @@
 import * as api from "../api.js";
 import { getComponent, bus } from "../../components.js";
 import { Store } from "../store.js";
+import { qs } from "../../dom.js";
 
 export async function initDocsController(winId="win_docs") {
   const refresh = async () => {
@@ -18,7 +19,7 @@ export async function initDocsController(winId="win_docs") {
     if (action === "remove")        { try { await api.removeDocument(item.id); } finally { await refresh(); } }
   });
 
-  const win = document.getElementById(winId);
+  const win = qs(`#${winId}`);
   const input = win?.querySelector(`#${winId}-upload`);
   const btn   = win?.querySelector(`#${winId}-upload-btn`);
   btn?.addEventListener("click", async () => {

--- a/app/static/js/ui/controllers/search.js
+++ b/app/static/js/ui/controllers/search.js
@@ -1,13 +1,14 @@
 // ui/controllers/search.js — semantic search
 import * as api from "../api.js";
+import { qs } from "../../dom.js";
 
 export function initSearchController(winId="win_search") {
-  const win = document.getElementById(winId);
+  const win = qs(`#${winId}`);
   if (!win) return;
-  const q = win.querySelector("#search_q");
-  const k = win.querySelector("#search_k");
-  const go = win.querySelector(".search-bar .btn");
-  const results = win.querySelector("#search_results");
+  const q = qs(`#${winId} #search_q`);
+  const k = qs(`#${winId} #search_k`);
+  const go = qs(`#${winId} .search-bar .btn`);
+  const results = qs(`#${winId} #search_results`);
 
   go.addEventListener("click", async () => {
     const data = await api.searchDocuments(q.value, Number(k.value || 5));

--- a/app/static/js/ui/controllers/sessions.js
+++ b/app/static/js/ui/controllers/sessions.js
@@ -3,6 +3,7 @@ import * as api from "../api.js";
 import { renderChatLog } from "../render.js";
 import { getComponent, bus } from "../../components.js";
 import { Store } from "../store.js";
+import { qs } from "../../dom.js";
 
 // highlight selected row
 let selectedIdx = null;
@@ -16,7 +17,7 @@ export async function initSessionsController(winId="win_sessions") {
     if (srcWin !== winId || elementId !== "session_list") return;
 
     // toggle selected
-    const list = document.querySelector(`#${winId} #session_list`);
+    const list = qs(`#${winId} #session_list`);
     if (list) {
       list.querySelectorAll(".list-item.selected").forEach(el => el.classList.remove("selected"));
       const row = list.querySelector(`.list-item[data-index="${index}"]`);
@@ -27,7 +28,7 @@ export async function initSessionsController(winId="win_sessions") {
     // load history
     Store.sessionId = item.session_id;
     const data = await api.getSession(Store.sessionId);
-    const log = document.querySelector("#win_chat #chat_log");
+    const log = qs("#win_chat #chat_log");
     if (log) renderChatLog(data.history || [], log);
   });
 }


### PR DESCRIPTION
## Summary
- add dom.js with qs helper for caching query selectors
- refactor controllers to replace document.getElementById/document.querySelector with cached qs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899d6ba3890832cb92b864a925c2ffb