### PR TITLE
Persist UI settings in localStorage

### DIFF
--- a/app/static/js/ui/store.js
+++ b/app/static/js/ui/store.js
@@ -1,11 +1,23 @@
 // ui/store.js — central app state
-const state = { sessionId: null, persona: "", inactiveDocs: new Set() };
+const storedPersona = localStorage.getItem("persona") || "";
+const storedDocs = localStorage.getItem("inactiveDocs");
+const state = {
+  sessionId: null,
+  persona: storedPersona,
+  inactiveDocs: new Set(storedDocs ? JSON.parse(storedDocs) : [])
+};
 export const Store = {
   get sessionId() { return state.sessionId; },
   set sessionId(v) { state.sessionId = v; },
   get persona() { return state.persona; },
-  set persona(v) { state.persona = v; },
+  set persona(v) {
+    state.persona = v;
+    localStorage.setItem("persona", v);
+  },
   isDocActive(id) { return !state.inactiveDocs.has(id); },
-  toggleDoc(id) { state.inactiveDocs.has(id) ? state.inactiveDocs.delete(id) : state.inactiveDocs.add(id); },
+  toggleDoc(id) {
+    state.inactiveDocs.has(id) ? state.inactiveDocs.delete(id) : state.inactiveDocs.add(id);
+    localStorage.setItem("inactiveDocs", JSON.stringify(Array.from(state.inactiveDocs)));
+  },
   inactiveList() { return Array.from(state.inactiveDocs); }
 };


### PR DESCRIPTION
## Summary
- Initialize store state from `localStorage` for persona and inactive documents
- Persist persona and document activity updates to `localStorage`

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899d6b762b4832cacdf155ea4877ef1