### PR TITLE
Sanitize markdown rendering with DOMPurify

### DIFF
--- a/app/static/js/ui/render.js
+++ b/app/static/js/ui/render.js
@@ -3,7 +3,10 @@ export function escapeHtml(s="") {
   return s.replaceAll("&","&amp;").replaceAll("<","&lt;").replaceAll(">","&gt;");
 }
 export function md(str="") {
-  return (window.marked?.parse) ? window.marked.parse(str) : escapeHtml(str).replaceAll("\n","<br>");
+  const html = (window.marked?.parse)
+    ? window.marked.parse(str)
+    : escapeHtml(str).replaceAll("\n", "<br>");
+  return (window.DOMPurify?.sanitize) ? window.DOMPurify.sanitize(html) : html;
 }
 export function renderChatLog(history, logEl) {
   logEl.innerHTML = "";

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -28,6 +28,7 @@
     </div>
   </div>
 
+  <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.3/dist/purify.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
   <script type="module" src="/static/js/main.js"></script>
 </body>

--- a/app/templates/splash.html
+++ b/app/templates/splash.html
@@ -44,5 +44,6 @@
       </div>
     </div>
   </div>
+  <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.3/dist/purify.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- sanitize Markdown rendering with DOMPurify in `render.js`
- load DOMPurify in `index.html` and `splash.html`

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6899d69a0ff0832c91b64c1f09648f24