### PR TITLE
Add AbortController to chat stream for cancellation

### DIFF
--- a/app/static/js/ui/api.js
+++ b/app/static/js/ui/api.js
@@ -72,7 +72,8 @@ export async function chat({ message, session_id, persona="", inactive=[] }) {
 }
 
 // Streaming chat using x-www-form-urlencoded to match legacy UI
-export async function chatStream({ message, session_id, persona="", inactive=[] }) {
+// Accepts an optional `signal` for cancellation via AbortController
+export async function chatStream({ message, session_id, persona="", inactive=[], signal }) {
   const params = new URLSearchParams();
   params.set("message", message);
   params.set("persona", persona);
@@ -84,7 +85,8 @@ export async function chatStream({ message, session_id, persona="", inactive=[] 
     method: "POST",
     headers: { "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8", "Accept": "*/*" },
     body: params.toString(),
-    credentials: "same-origin"
+    credentials: "same-origin",
+    signal
   });
   if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
   if (!res.body) throw new Error("No response body");


### PR DESCRIPTION
## Summary
- Allow `chatStream` API to accept AbortController signal
- Add cancel support in chat UI for new messages and window close

## Testing
- `pytest -q`
- `node sandbox-js/test_main.js`


------
https://chatgpt.com/codex/tasks/task_e_6899d6b4a390832c917ec97989439e55