### PR TITLE
Add user menu, settings modal, and segments viewer

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -5,7 +5,8 @@ from config import BASE_DIR, UPLOAD_DIR
 from app.routes.ui_routes import router as ui_router
 from app.routes.api_chat_search import router as chat_search_router
 from app.routes.api_file_ingest import router as ingest_router
-from app.routes.api_sessions import router as sessions_router 
+from app.routes.api_sessions import router as sessions_router
+from app.routes.api_segments import router as segments_router
 from app.auth.session import setup_auth, load_settings_from_config
 
 app = FastAPI()
@@ -17,5 +18,6 @@ manager, settings = setup_auth(app, load_settings_from_config())
 app.include_router(ui_router)
 app.include_router(chat_search_router)
 app.include_router(ingest_router)
-app.include_router(sessions_router) 
+app.include_router(sessions_router)
+app.include_router(segments_router)
 

--- a/app/routes/api_segments.py
+++ b/app/routes/api_segments.py
@@ -1,0 +1,29 @@
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import JSONResponse
+from utility.embedding_and_storing import db
+
+router = APIRouter()
+
+@router.get("/segments")
+async def list_segments():
+    data = db.collection.get(include=["documents", "metadatas", "ids"])
+    segments = []
+    docs = data.get("documents", [])
+    metas = data.get("metadatas", [])
+    ids = data.get("ids", [])
+    for doc, meta, _id in zip(docs, metas, ids):
+        segments.append({
+            "id": _id,
+            "source": meta.get("source", "unknown"),
+            "preview": doc[:80],
+            "priority": meta.get("priority", "medium")
+        })
+    return JSONResponse(content=segments)
+
+@router.delete("/segments/{seg_id}")
+async def delete_segment(seg_id: str):
+    try:
+        db.collection.delete(ids=[seg_id])
+        return {"status": "ok"}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -55,7 +55,7 @@ html, body {
   padding: 8px 12px;
   background: linear-gradient(180deg, hsl(var(--h) var(--sat) calc(var(--l-panel) + 2%)), hsl(var(--h) var(--sat) var(--l-panel)));
   border-bottom: 1px solid var(--border);
-  display: grid; grid-template-columns: auto auto 1fr;
+  display: grid; grid-template-columns: auto auto 1fr auto;
   align-items: center; gap: 10px;
 }
 .brand { font-size: 14px; color: var(--muted); letter-spacing: .3px; }
@@ -228,6 +228,7 @@ html, body {
 .msg { padding: 8px 10px; border-radius: 10px; background: hsl(var(--h) var(--sat) var(--l-panel)); border: 1px solid var(--border); }
 .msg.you { background: hsl(var(--h) var(--sat) calc(var(--l-panel) + 3%)); }
 .msg.assistant { background: hsl(var(--h) var(--sat) calc(var(--l-panel) + 1%)); }
+.msg.context { background: hsl(var(--h) var(--sat) calc(var(--l-panel) + 2%)); font-size: 12px; color: var(--muted); }
 
 .chat-input { display: grid; grid-template-columns: 1fr auto; gap: 8px; align-items: center; }
 .chat-input .input { width: 100%; }

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -10,7 +10,9 @@ import { initDocsController }     from "./ui/controllers/docs.js";
 import { initSessionsController } from "./ui/controllers/sessions.js";
 import { initChatController }     from "./ui/controllers/chat.js";
 import { initSearchController }   from "./ui/controllers/search.js";
+import { initSegmentsController } from "./ui/controllers/segments.js";
 import { openPersonaModal }       from "./ui/controllers/persona.js";
+import { openSettingsModal }      from "./ui/controllers/settings.js";
 
 import * as api from "./ui/api.js";
 import { Store } from "./ui/store.js";
@@ -29,9 +31,14 @@ initDocsController("win_docs");
 initSessionsController("win_sessions");
 initChatController();
 initSearchController("win_search");
+initSegmentsController("win_segments");
 
 // ensure we have a session at boot
 api.getOrCreateChatSession().then(id => Store.sessionId = id);
+api.getUser().then(u => {
+  const btn = document.getElementById("user-menu-trigger");
+  if (btn && u?.user) btn.textContent = `${u.user} ▾`;
+});
 
 // header menu
 initMenu(async (action) => {
@@ -43,4 +50,12 @@ initMenu(async (action) => {
   if (action === "edit-persona") {
     openPersonaModal();
   }
+  if (action === "settings") {
+    openSettingsModal();
+  }
 });
+
+// user menu
+initMenu((action) => {
+  if (action === "logout") window.location.href = "/logout";
+}, "user-menu-trigger", "user-menu-dropdown");

--- a/app/static/js/menu.js
+++ b/app/static/js/menu.js
@@ -1,7 +1,7 @@
 // menu.js — simple dropdown menu
-export function initMenu(onAction) {
-  const trigger = document.getElementById("menu-trigger");
-  const dropdown = document.getElementById("menu-dropdown");
+export function initMenu(onAction, triggerId="menu-trigger", dropdownId="menu-dropdown") {
+  const trigger = document.getElementById(triggerId);
+  const dropdown = document.getElementById(dropdownId);
   if (!trigger || !dropdown) return;
 
   function open() {

--- a/app/static/js/ui/api.js
+++ b/app/static/js/ui/api.js
@@ -41,6 +41,11 @@ export async function listDocuments() {
   return asJsonSafe(res);
 }
 
+export async function listSegments() {
+  const res = await ok(await fetch("/segments", { headers: JSON_HEADERS, credentials: "same-origin" }));
+  return asJsonSafe(res);
+}
+
 export async function removeDocument(source) {
   const fd = new FormData();
   fd.append("source", source);
@@ -48,10 +53,20 @@ export async function removeDocument(source) {
   return asJsonSafe(res);
 }
 
+export async function removeSegment(id) {
+  const res = await ok(await fetch(`/segments/${encodeURIComponent(id)}`, { method: "DELETE", headers: JSON_HEADERS, credentials: "same-origin" }));
+  return asJsonSafe(res);
+}
+
 export async function uploadDocuments(files) {
   const fd = new FormData();
   for (const f of files) fd.append("files", f);
   const res = await ok(await fetch("/upload", { method: "POST", body: fd, credentials: "same-origin" }));
+  return asJsonSafe(res);
+}
+
+export async function getUser() {
+  const res = await ok(await fetch("/user", { headers: JSON_HEADERS, credentials: "same-origin" }));
   return asJsonSafe(res);
 }
 

--- a/app/static/js/ui/controllers/chat.js
+++ b/app/static/js/ui/controllers/chat.js
@@ -32,6 +32,16 @@ export function initChatController() {
     if (!text) return;
     input.value = "";
     pushUser(text);
+    try {
+      const search = await api.searchDocuments(text);
+      const results = search.results || [];
+      if (results.length) {
+        const ctx = document.createElement("div");
+        ctx.className = "msg context";
+        ctx.innerHTML = `<em>Context:</em> ` + results.map(r => `${escapeHtml(r.source)}: ${escapeHtml(r.text)}`).join("<br>");
+        log.appendChild(ctx); log.scrollTop = log.scrollHeight;
+      }
+    } catch {}
     const bubble = pushAssistantBubble();
 
     try {

--- a/app/static/js/ui/controllers/segments.js
+++ b/app/static/js/ui/controllers/segments.js
@@ -1,0 +1,20 @@
+// ui/controllers/segments.js — list database segments
+import * as api from "../api.js";
+import { getComponent, bus } from "../../components.js";
+
+export async function initSegmentsController(winId="win_segments") {
+  const refresh = async () => {
+    const segs = await api.listSegments();
+    const comp = getComponent(winId, "segment_list");
+    if (comp) comp.render(segs);
+  };
+  await refresh();
+
+  bus.addEventListener("ui:list-action", async (ev) => {
+    const { winId: srcWin, elementId, action, item } = ev.detail || {};
+    if (srcWin !== winId || elementId !== "segment_list") return;
+    if (action === "remove") {
+      try { await api.removeSegment(item.id); } finally { await refresh(); }
+    }
+  });
+}

--- a/app/static/js/ui/controllers/settings.js
+++ b/app/static/js/ui/controllers/settings.js
@@ -1,0 +1,31 @@
+// ui/controllers/settings.js — settings modal
+import { createMiniWindowFromConfig, mountModal } from "../../window.js";
+import { Store } from "../store.js";
+
+export function openSettingsModal() {
+  const cfg = {
+    id: `win_settings_${crypto.randomUUID().slice(0,6)}`,
+    window_type: "window_generic",
+    title: "Settings",
+    modal: true,
+    Elements: [
+      { type: "text_field", label: "LLM Target Address", id: "llm_target_address", value: Store.llmTargetAddress || "" },
+      { type: "text_field", label: "llm_api_token", id: "llm_api_token", placeholder: "Optional", value: Store.llmToken || "" }
+    ]
+  };
+  const win = createMiniWindowFromConfig(cfg);
+  const wrap = mountModal(win);
+  const save = document.createElement("button");
+  save.className = "btn js-settings-save";
+  save.type = "button";
+  save.textContent = "Save";
+  win.querySelector(".form")?.appendChild(save);
+  save.addEventListener("click", () => {
+    const addr = win.querySelector("#llm_target_address")?.value || "";
+    const tok = win.querySelector("#llm_api_token")?.value || "";
+    Store.llmTargetAddress = addr;
+    Store.llmToken = tok;
+    wrap.remove();
+  });
+  return win;
+}

--- a/app/static/js/ui/store.js
+++ b/app/static/js/ui/store.js
@@ -1,10 +1,13 @@
 // ui/store.js — central app state
 const storedPersona = localStorage.getItem("persona") || "";
 const storedDocs = localStorage.getItem("inactiveDocs");
+const storedSettings = JSON.parse(localStorage.getItem("settings") || "{}");
 const state = {
   sessionId: null,
   persona: storedPersona,
-  inactiveDocs: new Set(storedDocs ? JSON.parse(storedDocs) : [])
+  inactiveDocs: new Set(storedDocs ? JSON.parse(storedDocs) : []),
+  llmTargetAddress: storedSettings.llm_target_address || "",
+  llmToken: storedSettings.llm_token || ""
 };
 export const Store = {
   get sessionId() { return state.sessionId; },
@@ -19,5 +22,22 @@ export const Store = {
     state.inactiveDocs.has(id) ? state.inactiveDocs.delete(id) : state.inactiveDocs.add(id);
     localStorage.setItem("inactiveDocs", JSON.stringify(Array.from(state.inactiveDocs)));
   },
-  inactiveList() { return Array.from(state.inactiveDocs); }
+  inactiveList() { return Array.from(state.inactiveDocs); },
+  get llmTargetAddress() { return state.llmTargetAddress; },
+  set llmTargetAddress(v) {
+    state.llmTargetAddress = v;
+    saveSettings();
+  },
+  get llmToken() { return state.llmToken; },
+  set llmToken(v) {
+    state.llmToken = v;
+    saveSettings();
+  }
 };
+
+function saveSettings() {
+  localStorage.setItem("settings", JSON.stringify({
+    llm_target_address: state.llmTargetAddress,
+    llm_token: state.llmToken
+  }));
+}

--- a/app/static/js/ui/windows.js
+++ b/app/static/js/ui/windows.js
@@ -3,5 +3,6 @@ export const windows = [
   { id: "win_docs",     window_type: "window_documents", title: "Document Library", col: "left"  },
   { id: "win_sessions", window_type: "window_sessions",  title: "Chat History",     col: "left"  },
   { id: "win_chat",     window_type: "window_chat_ui",   title: "Assistant Chat",   col: "right" },
-  { id: "win_search",   window_type: "window_search",    title: "Search Documents", col: "right" }
+  { id: "win_search",   window_type: "window_search",    title: "Search Documents", col: "right" },
+  { id: "win_segments", window_type: "window_segments",  title: "DB Segments",      col: "right" }
 ];

--- a/app/static/js/window.js
+++ b/app/static/js/window.js
@@ -91,6 +91,23 @@ const WindowTypes = {
     return wrap;
   },
 
+  "window_segments": (config, winId) => {
+    const layout = el("div", { class: "form" });
+    const listEl = createItemList(config.id || winId, {
+      id: "segment_list",
+      item_template: {
+        elements: [
+          { type: "text", bind: "source", class: "li-title" },
+          { type: "text", bind: "preview", class: "li-subtle" },
+          { type: "text", bind: "priority", class: "li-right" },
+          { type: "button", label: "Remove", action: "remove", variant: "danger" }
+        ]
+      }
+    });
+    layout.appendChild(listEl);
+    return layout;
+  },
+
   "window_persona": (config, winId) => {
   const wrap = el("div", { class: "form" });
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -16,9 +16,16 @@
         <div id="menu-dropdown" class="menu-dropdown" role="menu" aria-hidden="true">
           <button class="menu-item" data-action="new-chat" role="menuitem">New Chat</button>
           <button class="menu-item" data-action="edit-persona" role="menuitem">Persona…</button>
+          <button class="menu-item" data-action="settings" role="menuitem">Settings…</button>
         </div>
       </div>
       <div class="fill"></div>
+      <div class="menu user-menu">
+        <button id="user-menu-trigger" class="menu-trigger" aria-haspopup="true" aria-expanded="false">User ▾</button>
+        <div id="user-menu-dropdown" class="menu-dropdown" role="menu" aria-hidden="true">
+          <button class="menu-item" data-action="logout" role="menuitem">Log Out</button>
+        </div>
+      </div>
     </div>
 
     <div class="columns" id="columns">

--- a/utility/db_manager.py
+++ b/utility/db_manager.py
@@ -70,6 +70,7 @@ class DBManager:
             "source": source,
             "metadata_tags": ", ".join(tags) if tags else "Placeholder",
             "segment_index": segment_index,
+            "priority": "medium",
         }
         if start is not None and end is not None:
             metadata["start_char"] = start

--- a/utility/session_store.py
+++ b/utility/session_store.py
@@ -76,3 +76,11 @@ class SessionStore:
     # ------------------------------------------------------------------
     def exists(self, session_id: str) -> bool:
         return self._session_path(session_id).exists()
+
+    # ------------------------------------------------------------------
+    def prune_empty(self) -> None:
+        """Remove sessions with no history."""
+        for entry in list(self.list_sessions()):
+            session = self.load(entry["id"])
+            if session and not session.history:
+                self.delete(entry["id"])


### PR DESCRIPTION
## Summary
- Add configurable header menus with user dropdown and logout
- Introduce settings modal with LLM target/address fields stored in local settings
- Show search context in chat, prune empty sessions, and add DB segments window API

## Testing
- `python -m py_compile app/main.py app/routes/api_sessions.py app/routes/api_segments.py utility/db_manager.py utility/session_store.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899ed0a20c4832c87d7da889c091728