### PR TITLE
feat: add user settings and pluggable LLM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ parsed_texts/
 
 # --- Query result data ---
 *.json
+!prompts/*.json
 
 # --- Model cache or sentence-transformers ---
 cache/

--- a/app/llm/__init__.py
+++ b/app/llm/__init__.py
@@ -1,0 +1,1 @@
+# llm package

--- a/app/llm/base.py
+++ b/app/llm/base.py
@@ -1,0 +1,9 @@
+from typing import Any, Dict
+
+class BaseLLM:
+    def __init__(self, model: str | None = None, **kwargs: Any) -> None:
+        self.model = model
+
+    def generate(self, prompt: str, **kwargs: Any) -> str:
+        """Return a string completion."""
+        raise NotImplementedError

--- a/app/llm/ollama_llm.py
+++ b/app/llm/ollama_llm.py
@@ -1,0 +1,21 @@
+import requests
+from typing import Any
+from .base import BaseLLM
+from config import OLLAMA_BASE_URL, OLLAMA_MODEL  # add these if missing
+
+class OllamaLLM(BaseLLM):
+    def __init__(self, model: str | None = None, base_url: str | None = None, **kwargs: Any) -> None:
+        super().__init__(model=model or OLLAMA_MODEL)
+        self.base_url = base_url or OLLAMA_BASE_URL
+
+    def generate(self, prompt: str, **kwargs: Any) -> str:
+        # Simple non-stream generate API
+        resp = requests.post(
+            f"{self.base_url}/api/generate",
+            json={"model": self.model, "prompt": prompt, "stream": False} | kwargs,
+            timeout=120,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        # 'response' is plain text for /api/generate
+        return data.get("response", "")

--- a/app/llm/openai_llm.py
+++ b/app/llm/openai_llm.py
@@ -1,0 +1,8 @@
+from typing import Any
+from .base import BaseLLM
+
+class OpenAILLM(BaseLLM):
+    def generate(self, prompt: str, **kwargs: Any) -> str:
+        # Intentionally empty skeleton. Wire OpenAI SDK later.
+        # Return a placeholder so the app doesn't crash if misconfigured.
+        return "[OpenAI LLM not configured]"

--- a/app/main.py
+++ b/app/main.py
@@ -7,6 +7,7 @@ from app.routes.api_chat_search import router as chat_search_router
 from app.routes.api_file_ingest import router as ingest_router
 from app.routes.api_sessions import router as sessions_router
 from app.routes.api_segments import router as segments_router
+from app.routes.api_settings import router as settings_router
 from app.auth.session import setup_auth, load_settings_from_config
 
 app = FastAPI()
@@ -20,4 +21,5 @@ app.include_router(chat_search_router)
 app.include_router(ingest_router)
 app.include_router(sessions_router)
 app.include_router(segments_router)
+app.include_router(settings_router)
 

--- a/app/routes/api_settings.py
+++ b/app/routes/api_settings.py
@@ -1,0 +1,29 @@
+from fastapi import APIRouter, HTTPException
+from typing import Dict, Any
+from app.services.user_settings import UserSettings, load_settings, update_settings, list_prompt_templates, get_prompt_template
+
+router = APIRouter(prefix="/api", tags=["settings"])
+
+@router.get("/settings/{user_id}", response_model=UserSettings)
+def get_settings(user_id: str):
+    return load_settings(user_id)
+
+@router.patch("/settings/{user_id}", response_model=UserSettings)
+def patch_settings(user_id: str, patch: Dict[str, Any]):
+    try:
+        return update_settings(user_id, patch)
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+@router.get("/prompt-templates")
+def list_prompts():
+    return [p.model_dump() for p in list_prompt_templates()]
+
+@router.get("/prompt-templates/{tid}")
+def get_prompt(tid: str):
+    p = get_prompt_template(tid)
+    if not p:
+        raise HTTPException(status_code=404, detail="template not found")
+    return p.model_dump()
+
+# (OPTIONAL) POST/PUT to add templates can be added later.

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,0 +1,1 @@
+# services package

--- a/app/services/llm_factory.py
+++ b/app/services/llm_factory.py
@@ -1,0 +1,12 @@
+from typing import Optional
+from app.llm.base import BaseLLM
+from app.llm.ollama_llm import OllamaLLM
+from app.llm.openai_llm import OpenAILLM
+
+def make_llm(provider: str, model: Optional[str]) -> BaseLLM:
+    if provider == "ollama":
+        return OllamaLLM(model=model)
+    if provider == "openai":
+        return OpenAILLM(model=model)
+    # Fallback to ollama
+    return OllamaLLM(model=model)

--- a/app/services/prompt_engine.py
+++ b/app/services/prompt_engine.py
@@ -1,0 +1,23 @@
+from typing import Dict, Any
+from .user_settings import get_prompt_template, list_prompt_templates, load_settings
+from .llm_factory import make_llm
+
+def render_prompt(template: dict, vars: Dict[str, Any]) -> str:
+    # Minimal formatter; supports {var} placeholders in 'system' and/or 'content'
+    system = (template.get("system") or "").format(**vars)
+    content = (template.get("content") or "").format(**vars)
+    prompt = (system + "\n\n" + content).strip() if system else content
+    return prompt
+
+def generate_reply(user_id: str, vars: Dict[str, Any]) -> str:
+    settings = load_settings(user_id)
+    tmpl = None
+    if settings.prompt_template_id:
+        pt = get_prompt_template(settings.prompt_template_id)
+        if pt:
+            tmpl = pt.model_dump()
+    if not tmpl:
+        tmpl = {"content": "{message}"}  # trivial fallback template
+    prompt = render_prompt(tmpl, vars)
+    llm = make_llm(settings.llm_provider, settings.llm_model or None)
+    return llm.generate(prompt)

--- a/app/services/user_settings.py
+++ b/app/services/user_settings.py
@@ -1,0 +1,73 @@
+from pathlib import Path
+from typing import Optional, Dict, Any, List, Literal
+from pydantic import BaseModel, Field
+import json
+
+USERS_DIR = Path("users")
+USERS_DIR.mkdir(parents=True, exist_ok=True)
+
+class UserSettings(BaseModel):
+    user_id: str
+    # LLM configuration
+    llm_provider: Literal["ollama", "openai"] = "ollama"
+    llm_model: str = ""  # if empty, use provider default from config.py
+    # Prompting
+    prompt_template_id: Optional[str] = None
+    # Optional knobs
+    temperature: float = 0.2
+    top_p: float = 0.95
+    max_tokens: int = 512
+
+def _user_path(user_id: str) -> Path:
+    return USERS_DIR / f"{user_id}.json"
+
+def load_settings(user_id: str) -> UserSettings:
+    p = _user_path(user_id)
+    if not p.exists():
+        # initialize with defaults
+        s = UserSettings(user_id=user_id)
+        save_settings(s)
+        return s
+    data = json.loads(p.read_text(encoding="utf-8"))
+    return UserSettings(**data)
+
+def save_settings(s: UserSettings) -> None:
+    p = _user_path(s.user_id)
+    p.write_text(s.model_dump_json(indent=2), encoding="utf-8")
+
+def update_settings(user_id: str, patch: Dict[str, Any]) -> UserSettings:
+    s = load_settings(user_id)
+    s = s.model_copy(update=patch)
+    save_settings(s)
+    return s
+
+# Prompt templates
+PROMPTS_DIR = Path("prompts")
+PROMPTS_DIR.mkdir(parents=True, exist_ok=True)
+
+class PromptTemplate(BaseModel):
+    id: str
+    name: str
+    description: Optional[str] = None
+    # One of these fields may exist depending on style; keep flexible
+    system: Optional[str] = None
+    content: Optional[str] = None
+    # Optional inputs schema (names the vars the template expects)
+    inputs: List[str] = Field(default_factory=list)
+    meta: Dict[str, Any] = Field(default_factory=dict)
+
+def list_prompt_templates() -> List[PromptTemplate]:
+    out: List[PromptTemplate] = []
+    for f in PROMPTS_DIR.glob("*.json"):
+        try:
+            data = json.loads(f.read_text(encoding="utf-8"))
+            out.append(PromptTemplate(**data))
+        except Exception:
+            continue
+    return out
+
+def get_prompt_template(tid: str) -> Optional[PromptTemplate]:
+    f = PROMPTS_DIR / f"{tid}.json"
+    if not f.exists():
+        return None
+    return PromptTemplate(**json.loads(f.read_text(encoding="utf-8")))

--- a/app/static/js/ui.js
+++ b/app/static/js/ui.js
@@ -37,6 +37,15 @@ export const Field = {
       if (value) textarea.value = value;
       return textarea;
     },
+    "select": ({ id, name, options = [], value = "" }) => {
+      const sel = el("select", { id, name: name || id, class: "input" });
+      for (const opt of options) {
+        const o = el("option", { value: opt.value }, [opt.label || opt.value]);
+        if (opt.value === value) o.selected = true;
+        sel.appendChild(o);
+      }
+      return sel;
+    },
     "text": ({ text = "", className = "" }) => {
       const s = el("span", {}, [String(text)]);
       if (className) s.className = className;

--- a/app/static/js/ui/api.js
+++ b/app/static/js/ui/api.js
@@ -75,6 +75,26 @@ export async function searchDocuments(q, top_k=5) {
   return asJsonSafe(res);
 }
 
+export async function getSettings(userId) {
+  const res = await ok(await fetch(`/api/settings/${encodeURIComponent(userId)}`, { headers: JSON_HEADERS, credentials: "same-origin" }));
+  return asJsonSafe(res);
+}
+
+export async function patchSettings(userId, payload) {
+  const res = await ok(await fetch(`/api/settings/${encodeURIComponent(userId)}`, {
+    method: "PATCH",
+    headers: { ...JSON_HEADERS, "Content-Type": "application/json" },
+    credentials: "same-origin",
+    body: JSON.stringify(payload)
+  }));
+  return asJsonSafe(res);
+}
+
+export async function listPromptTemplates() {
+  const res = await ok(await fetch(`/api/prompt-templates`, { headers: JSON_HEADERS, credentials: "same-origin" }));
+  return asJsonSafe(res);
+}
+
 // Non-streaming fallback (if you have a non-streaming route)
 export async function chat({ message, session_id, persona="", inactive=[] }) {
   const fd = new FormData();

--- a/app/static/js/ui/controllers/chat.js
+++ b/app/static/js/ui/controllers/chat.js
@@ -3,6 +3,7 @@ import * as api from "../api.js";
 import { Store } from "../store.js";
 import { md, escapeHtml } from "../render.js";
 import { qs } from "../../dom.js";
+import { runSearch } from "./search.js";
 
 export function initChatController() {
   const chatWin = qs("#win_chat");
@@ -32,16 +33,7 @@ export function initChatController() {
     if (!text) return;
     input.value = "";
     pushUser(text);
-    try {
-      const search = await api.searchDocuments(text);
-      const results = search.results || [];
-      if (results.length) {
-        const ctx = document.createElement("div");
-        ctx.className = "msg context";
-        ctx.innerHTML = `<em>Context:</em> ` + results.map(r => `${escapeHtml(r.source)}: ${escapeHtml(r.text)}`).join("<br>");
-        log.appendChild(ctx); log.scrollTop = log.scrollHeight;
-      }
-    } catch {}
+    runSearch(text);
     const bubble = pushAssistantBubble();
 
     try {

--- a/app/static/js/ui/controllers/search.js
+++ b/app/static/js/ui/controllers/search.js
@@ -2,64 +2,66 @@
 import * as api from "../api.js";
 import { escapeHtml } from "../render.js";
 
-export function initSearchController(winId = "win_search") {
+export async function runSearch(query, winId = "win_search") {
   const win = document.getElementById(winId);
   if (!win) return;
-
   const q = win.querySelector("#search_q");
   const k = win.querySelector("#search_k");
-  const go = win.querySelector(".search-bar .btn");
   const results = win.querySelector("#search_results");
+  if (query !== undefined) q.value = query;
+  const qtext = q.value.trim();
+  const topK = Number(k.value || 5);
+  if (!qtext) {
+    results.innerHTML = "";
+    return;
+  }
 
-  async function run() {
-    const query = q.value.trim();
-    const topK = Number(k.value || 5);
-    if (!query) {
-      results.innerHTML = "";
+  results.innerHTML = `<div class="li-subtle">Searching…</div>`;
+
+  try {
+    const data = await api.searchDocuments(qtext, topK);
+    const arr = (data && data.results) || [];
+
+    results.innerHTML = "";
+    if (!arr.length) {
+      results.innerHTML = `<div class="li-subtle">No results</div>`;
       return;
     }
 
-    results.innerHTML = `<div class="li-subtle">Searching…</div>`;
+    for (const r of arr) {
+      const card = document.createElement("div");
+      card.className = "result-card";
 
-    try {
-      const data = await api.searchDocuments(query, topK);
-      const arr = (data && data.results) || [];
+      const text = escapeHtml(r?.text ?? "");
+      const source = escapeHtml(r?.source ?? "");
+      const score =
+        typeof r?.score === "number"
+          ? r.score.toFixed(3)
+          : escapeHtml(String(r?.score ?? ""));
+      const page = r?.page ?? "?";
 
-      results.innerHTML = "";
-      if (!arr.length) {
-        results.innerHTML = `<div class="li-subtle">No results</div>`;
-        return;
-      }
-
-      for (const r of arr) {
-        const card = document.createElement("div");
-        card.className = "result-card";
-
-        const text = escapeHtml(r?.text ?? "");
-        const source = escapeHtml(r?.source ?? "");
-        const score =
-          typeof r?.score === "number"
-            ? r.score.toFixed(3)
-            : escapeHtml(String(r?.score ?? ""));
-        const page = r?.page ?? "?";
-
-        card.innerHTML = `
+      card.innerHTML = `
           <div>${text}</div>
           <div class="result-meta">
             <span>Source: ${source}</span>
             <span>Score: ${score} • Page: ${page}</span>
           </div>`;
-        results.appendChild(card);
-      }
-    } catch (e) {
-      results.innerHTML = `<div class="li-subtle">Error: ${escapeHtml(
-        e?.message || String(e)
-      )}</div>`;
+      results.appendChild(card);
     }
+  } catch (e) {
+    results.innerHTML = `<div class="li-subtle">Error: ${escapeHtml(
+      e?.message || String(e)
+    )}</div>`;
   }
+}
 
-  go.addEventListener("click", run);
+export function initSearchController(winId = "win_search") {
+  const win = document.getElementById(winId);
+  if (!win) return;
+  const q = win.querySelector("#search_q");
+  const go = win.querySelector(".search-bar .btn");
+  go.addEventListener("click", () => runSearch(undefined, winId));
   q.addEventListener("keydown", (e) => {
-    if (e.key === "Enter") run();
+    if (e.key === "Enter") runSearch(undefined, winId);
   });
 }

--- a/app/static/js/ui/controllers/settings.js
+++ b/app/static/js/ui/controllers/settings.js
@@ -1,16 +1,38 @@
 // ui/controllers/settings.js — settings modal
 import { createMiniWindowFromConfig, mountModal } from "../../window.js";
-import { Store } from "../store.js";
+import * as api from "../api.js";
 
-export function openSettingsModal() {
+export async function openSettingsModal() {
+  const user = await api.getUser();
+  const userId = user?.user || "default";
+  const [settings, prompts] = await Promise.all([
+    api.getSettings(userId),
+    api.listPromptTemplates()
+  ]);
+
+  const promptOptions = [{ value: "", label: "(default)" }];
+  for (const t of prompts) {
+    promptOptions.push({ value: t.id, label: t.name || t.id });
+  }
+
   const cfg = {
     id: `win_settings_${crypto.randomUUID().slice(0,6)}`,
     window_type: "window_generic",
     title: "Settings",
     modal: true,
     Elements: [
-      { type: "text_field", label: "LLM Target Address", id: "llm_target_address", value: Store.llmTargetAddress || "" },
-      { type: "text_field", label: "llm_api_token", id: "llm_api_token", placeholder: "Optional", value: Store.llmToken || "" }
+      {
+        type: "select",
+        label: "LLM Provider",
+        id: "llm_provider",
+        options: [
+          { value: "ollama", label: "Ollama" },
+          { value: "openai", label: "OpenAI" },
+        ],
+        value: settings.llm_provider
+      },
+      { type: "text_field", label: "LLM Model", id: "llm_model", value: settings.llm_model || "" },
+      { type: "select", label: "Prompt Template", id: "prompt_template_id", options: promptOptions, value: settings.prompt_template_id || "" }
     ]
   };
   const win = createMiniWindowFromConfig(cfg);
@@ -20,11 +42,13 @@ export function openSettingsModal() {
   save.type = "button";
   save.textContent = "Save";
   win.querySelector(".form")?.appendChild(save);
-  save.addEventListener("click", () => {
-    const addr = win.querySelector("#llm_target_address")?.value || "";
-    const tok = win.querySelector("#llm_api_token")?.value || "";
-    Store.llmTargetAddress = addr;
-    Store.llmToken = tok;
+  save.addEventListener("click", async () => {
+    const payload = {
+      llm_provider: win.querySelector("#llm_provider")?.value,
+      llm_model: win.querySelector("#llm_model")?.value,
+      prompt_template_id: win.querySelector("#prompt_template_id")?.value || null,
+    };
+    await api.patchSettings(userId, payload);
     wrap.remove();
   });
   return win;

--- a/config.py
+++ b/config.py
@@ -21,5 +21,7 @@ MIN_TOP_K = 1
 MAX_TOP_K = 20
 
 # === Ollama ===
-OLLAMA_URL = os.getenv("OLLAMA_URL", "http://localhost:11434/api/generate")
-OLLAMA_MODEL = os.getenv("OLLAMA_MODEL", "mistral:7b")
+OLLAMA_BASE_URL = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434")
+OLLAMA_MODEL = os.getenv("OLLAMA_MODEL", "llama3")
+# Backwards compatibility for legacy code expecting OLLAMA_URL
+OLLAMA_URL = f"{OLLAMA_BASE_URL}/api/generate"

--- a/prompts/default.json
+++ b/prompts/default.json
@@ -1,0 +1,7 @@
+{
+  "id": "default",
+  "name": "Plain Relay",
+  "description": "Minimal pass-through of the user's message.",
+  "content": "{message}",
+  "inputs": ["message"]
+}

--- a/prompts/tech_helper.json
+++ b/prompts/tech_helper.json
@@ -1,0 +1,8 @@
+{
+  "id": "tech_helper",
+  "name": "Technical Helper",
+  "description": "Asks for concise, technical answers.",
+  "system": "You are a precise, terse technical assistant.",
+  "content": "Question: {message}\nConstraints: be direct; avoid fluff.",
+  "inputs": ["message"]
+}


### PR DESCRIPTION
## Summary
- add JSON-backed user settings with prompt template support
- expose settings and prompt template APIs
- add pluggable LLM framework with Ollama provider and placeholder OpenAI provider
- wire settings modal to backend API and trigger search panel per chat

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a0762a254832cb15855728b93fc1f