### PR TITLE
Ensure resize bar sticks to window bottom and expose full prompts

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -142,6 +142,8 @@ html, body {
   overflow: hidden;
   margin: 8px 0 18px;
   outline: none;
+  display: flex;
+  flex-direction: column;
 }
 .miniwin .titlebar {
   display: grid; grid-template-columns: 1fr auto; align-items: center; gap: 8px;
@@ -167,15 +169,18 @@ html, body {
   padding: 14px;
   transition: grid-template-rows .2s ease, padding .2s ease, opacity .2s ease;
   display: grid; grid-template-rows: 1fr;
+  flex: 1;
+  min-height: 0;
 }
 .miniwin.collapsed .content { grid-template-rows: 0fr; padding-top: 0; padding-bottom: 0; opacity: .0; }
-.miniwin .content-inner { overflow: auto; }
+.miniwin .content-inner { overflow: auto; min-height: 0; }
 
 .win-resizer-y {
   height: 8px;
   cursor: ns-resize;
   user-select: none;
   background: hsl(var(--h) var(--sat) var(--l-panel));
+  flex: 0 0 8px;
 }
 .win-resizer-y:hover { background: hsl(var(--h) var(--sat) calc(var(--l-panel) + 4%)); }
 

--- a/core/settings.py
+++ b/core/settings.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Optional, Dict, Any, List, Literal
 import json
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ConfigDict
 
 from .prompts import loader as prompt_loader
 
@@ -45,6 +45,8 @@ PROMPTS_DIR = Path("prompts")
 PROMPTS_DIR.mkdir(parents=True, exist_ok=True)
 
 class PromptTemplate(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
     id: str
     name: str
     description: Optional[str] = None

--- a/tests/test_core_prompt.py
+++ b/tests/test_core_prompt.py
@@ -3,6 +3,7 @@ sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
 from core.prompts import renderer
 from core.sessions import ChatExchange
+from core.settings import get_prompt_template
 
 
 def test_build_prompt_with_context_persona_history():
@@ -21,3 +22,9 @@ def test_build_prompt_with_context_persona_history():
     assert "User: hi" in prompt and "Assistant: there" in prompt
     assert "ctx" in prompt
     assert "question" in prompt
+
+
+def test_prompt_template_contains_extra_fields():
+    tmpl = get_prompt_template("rag_chat")
+    data = tmpl.model_dump()
+    assert "context_item_format" in data


### PR DESCRIPTION
## Summary
- Keep mini window resizer anchored to the bottom and allow content to scroll when the window is shortened
- Allow prompt templates to include arbitrary fields so prompt editor shows full context
- Test that prompt template extra fields are preserved

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a4f305d14832c9abf7476f24907fb