### PR TITLE
Improve window drag ordering and chat layout

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -173,6 +173,7 @@ html, body {
   min-height: 0;
 }
 .miniwin.collapsed .content { grid-template-rows: 0fr; padding-top: 0; padding-bottom: 0; opacity: .0; }
+.miniwin.collapsed .win-resizer-y { display: none; }
 .miniwin .content-inner { overflow: auto; min-height: 0; }
 
 .win-resizer-y {
@@ -270,19 +271,27 @@ html, body {
 .list-item.selected .li-title { color: var(--text); }
 
 /* ===== Chat ===== */
-.chat-log {
+.chat-window {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+}
+.chat-window .chat-log {
   display: grid; gap: 8px; padding: 8px;
   border: 1px solid var(--border); border-radius: 12px;
   background: hsl(var(--h) var(--sat) calc(var(--l-bg) + 2%));
-  max-height: 40vh; overflow: auto;
+  overflow: auto;
+  flex: 1 1 auto;
+  min-height: 0;
 }
 .msg { padding: 8px 10px; border-radius: 10px; background: hsl(var(--h) var(--sat) var(--l-panel)); border: 1px solid var(--border); }
 .msg.you { background: hsl(var(--h) var(--sat) calc(var(--l-panel) + 3%)); }
 .msg.assistant { background: hsl(var(--h) var(--sat) calc(var(--l-panel) + 1%)); }
 .msg.context { background: hsl(var(--h) var(--sat) calc(var(--l-panel) + 2%)); font-size: 12px; color: var(--muted); }
 
-.chat-input { display: grid; grid-template-columns: 1fr auto; gap: 8px; align-items: center; }
-.chat-input .input { width: 100%; }
+.chat-window .chat-input { display: grid; grid-template-columns: 1fr auto; gap: 8px; align-items: center; margin-top: 8px; }
+.chat-window .chat-input .input { width: 100%; }
 
 /* ===== Search ===== */
 .search-bar { display: grid; grid-template-columns: 1fr 130px auto; gap: 8px; align-items: center; }

--- a/app/static/js/dnd.js
+++ b/app/static/js/dnd.js
@@ -29,7 +29,18 @@ export function handleDrop(draggingWin, isModalDrag, columnsEl, cols, e, getDrop
     draggingWin.style.pointerEvents = "";
 
     if (targetCol) {
-      targetCol.appendChild(draggingWin);
+      // Determine insertion point within the column based on pointer Y
+      const siblings = [...targetCol.querySelectorAll('.miniwin')].filter(w => w !== draggingWin);
+      let inserted = false;
+      for (const sib of siblings) {
+        const rect = sib.getBoundingClientRect();
+        if (e.clientY < rect.top + rect.height / 2) {
+          targetCol.insertBefore(draggingWin, sib);
+          inserted = true;
+          break;
+        }
+      }
+      if (!inserted) targetCol.appendChild(draggingWin);
       draggingWin.focus({ preventScroll: true });
     }
   } else {
@@ -105,6 +116,14 @@ export function initWindowDnD() {
     if (!win) return;
     const collapsed = win.classList.toggle("collapsed");
     btn.setAttribute("aria-pressed", String(collapsed));
+    if (collapsed) {
+      // Remember current height so it can be restored when expanded
+      win.dataset.prevHeight = win.style.height;
+      win.style.height = '';
+    } else if (win.dataset.prevHeight) {
+      win.style.height = win.dataset.prevHeight;
+      delete win.dataset.prevHeight;
+    }
   });
 
   document.addEventListener("click", (e) => {

--- a/app/static/js/window.js
+++ b/app/static/js/window.js
@@ -70,7 +70,7 @@ const WindowTypes = {
   },
 
   "window_chat_ui": (config, winId) => {
-    const wrap = el("div", { class: "form" });
+    const wrap = el("div", { class: "chat-window" });
     const log = el("div", { class: "chat-log", id: "chat_log" });
     const input = Field.create({ type: "text_field", id: "chat_input", placeholder: "Type a message..." });
     const send = el("button", { class: "btn", type: "button" }, ["Send"]);


### PR DESCRIPTION
## Summary
- allow reordering windows within columns via drag and drop
- keep chat input fixed to bottom and resize chat log with the window
- fully collapse windows when minimized

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a534b2280832c9c323f511c4f1d1c