### PR TITLE
refactor: modularize window renderers

### DIFF
--- a/app/static/js/windows/window_chat_ui.js
+++ b/app/static/js/windows/window_chat_ui.js
@@ -1,0 +1,12 @@
+import { el, Field } from "../ui.js";
+
+export function render(config, winId) {
+  const wrap = el("div", { class: "chat-window" });
+  const log = el("div", { class: "chat-log", id: "chat_log" });
+  const input = Field.create({ type: "text_field", id: "chat_input", placeholder: "Type a message..." });
+  const send = el("button", { class: "btn", type: "button" }, ["Send"]);
+  const bar = el("div", { class: "chat-input" }, [input, send]);
+  wrap.append(log, bar);
+  wrap.dataset.winId = config.id || winId;
+  return wrap;
+}

--- a/app/static/js/windows/window_documents.js
+++ b/app/static/js/windows/window_documents.js
@@ -1,0 +1,27 @@
+import { el } from "../ui.js";
+import { createItemList } from "../components.js";
+
+export function render(config, winId) {
+  const layout = el("div", { class: "form" });
+
+  const id = config.id || winId;
+  const upWrap = el("div", { class: "row" });
+  const upInput = el("input", { type: "file", multiple: true, id: `${id}-upload`, style: { maxWidth: "100%" } });
+  const upBtn = el("button", { class: "btn", type: "button", id: `${id}-upload-btn` }, ["Upload"]);
+  upWrap.append(el("label", {}, ["Upload Documents"]), upInput, upBtn);
+  layout.appendChild(upWrap);
+
+  const listEl = createItemList(id, {
+    id: "doc_list",
+    item_template: {
+      elements: [
+        { type: "text", bind: "title", class: "li-title" },
+        { type: "text", bind: "segments", class: "li-meta" },
+        { type: "button", toggle: { prop: "active", on: "Deactivate", off: "Activate", action: "toggle_active" } },
+        { type: "button", label: "Remove", action: "remove", variant: "danger" }
+      ]
+    }
+  });
+  layout.appendChild(listEl);
+  return layout;
+}

--- a/app/static/js/windows/window_generic.js
+++ b/app/static/js/windows/window_generic.js
@@ -1,0 +1,25 @@
+import { el, Field, fieldRow } from "../ui.js";
+import { createItemList } from "../components.js";
+
+export function render(config, winId) {
+  const form = el("form", { class: "form", autocomplete: "off" });
+  (config.Elements || []).forEach((e, idx) => {
+    const baseId = e.id || (e.name ? e.name.toLowerCase().replace(/\s+/g, "_") : `field_${idx+1}`);
+    const id = `${baseId}`;
+    const label = e.label || e.name || baseId;
+
+    if (e.type === "item_list") {
+      const listEl = createItemList(config.id || winId, { ...e, id });
+      const row = el("div", { class: "row" }, [
+        el("label", {}, [label]),
+        listEl
+      ]);
+      form.appendChild(row);
+      return;
+    }
+
+    const input = Field.create({ ...e, id });
+    form.appendChild(fieldRow(id, label, input));
+  });
+  return form;
+}

--- a/app/static/js/windows/window_persona.js
+++ b/app/static/js/windows/window_persona.js
@@ -1,0 +1,23 @@
+import { el, Field } from "../ui.js";
+
+export function render(config, winId) {
+  const wrap = el("div", { class: "form" });
+
+  const textarea = Field.create({
+    type: "text_area",
+    id: "persona_text",
+    value: config.value || "",
+    rows: 10
+  });
+  const row = el("div", { class: "row" }, [
+    el("label", { for: "persona_text" }, ["Persona"]),
+    textarea
+  ]);
+
+  const actions = el("div", { class: "row" }, [
+    el("button", { type: "button", class: "btn js-persona-save" }, ["Save"])
+  ]);
+
+  wrap.append(row, actions);
+  return wrap;
+}

--- a/app/static/js/windows/window_prompt_editor.js
+++ b/app/static/js/windows/window_prompt_editor.js
@@ -1,0 +1,18 @@
+import { el } from "../ui.js";
+
+export function render(config, winId) {
+  const wrap = el("div", { class: "form" });
+  const selectRow = el("div", { class: "row" }, [
+    el("label", { for: "tmpl_select" }, ["Template"]),
+    el("select", { id: "tmpl_select", class: "input" })
+  ]);
+  const textRow = el("div", { class: "row" }, [
+    el("label", { for: "tmpl_text" }, ["JSON"]),
+    el("textarea", { id: "tmpl_text", class: "textarea", style: { fontFamily: "monospace", minHeight: "200px" } })
+  ]);
+  const actions = el("div", { class: "row" }, [
+    el("button", { type: "button", class: "btn", id: "tmpl_save" }, ["Save"])
+  ]);
+  wrap.append(selectRow, textRow, actions);
+  return wrap;
+}

--- a/app/static/js/windows/window_search.js
+++ b/app/static/js/windows/window_search.js
@@ -1,0 +1,13 @@
+import { el, Field } from "../ui.js";
+
+export function render(config, winId) {
+  const wrap = el("div", { class: "form" });
+  const q = Field.create({ type: "text_field", id: "search_q", placeholder: "Enter search text..." });
+  const k = Field.create({ type: "number_field", id: "search_k", value: 5, min: 1, max: 50 });
+  const go = el("button", { class: "btn", type: "button" }, ["Search"]);
+  const bar = el("div", { class: "search-bar" }, [q, k, go]);
+  const results = el("div", { class: "results", id: "search_results" });
+  wrap.append(bar, results);
+  wrap.dataset.winId = config.id || winId;
+  return wrap;
+}

--- a/app/static/js/windows/window_segment_view.js
+++ b/app/static/js/windows/window_segment_view.js
@@ -1,0 +1,27 @@
+import { el } from "../ui.js";
+import { md } from "../ui/render.js";
+
+export function render(config, winId) {
+  const seg = config.segment || {};
+  const wrap = el("div", { class: "form segment-view" });
+  const metaTop = el("div", { class: "row" }, [
+    el("label", {}, ["Source"]),
+    el("span", { class: "li-subtle" }, [
+      `${seg.source || ""}${seg.page != null ? `, p.${seg.page}` : ""}`
+    ])
+  ]);
+  const metaDates = el("div", { class: "row" }, [
+    el("label", {}, ["Dates"]),
+    el("span", { class: "li-subtle" }, [
+      `${seg.created_at || ""}${seg.updated_at ? ` • ${seg.updated_at}` : ""}`
+    ])
+  ]);
+  const tags = el("div", { class: "row" }, [
+    el("label", {}, ["Tags"]),
+    el("span", { class: "li-subtle" }, [(seg.tags || []).join(", ")])
+  ]);
+  const body = el("div", { class: "segment-text" });
+  body.innerHTML = md(seg.text || "");
+  wrap.append(metaTop, metaDates, tags, body);
+  return wrap;
+}

--- a/app/static/js/windows/window_segments.js
+++ b/app/static/js/windows/window_segments.js
@@ -1,0 +1,20 @@
+import { el } from "../ui.js";
+import { createItemList } from "../components.js";
+
+export function render(config, winId) {
+  const layout = el("div", { class: "form" });
+  const listEl = createItemList(config.id || winId, {
+    id: "segment_list",
+    item_template: {
+      elements: [
+        { type: "text", bind: "source", class: "li-title" },
+        { type: "text", bind: "priority", class: "li-meta" },
+        { type: "text", bind: "preview", class: "li-subtle" },
+        { type: "button", label: "Open", action: "open" },
+        { type: "button", label: "Remove", action: "remove", variant: "danger" }
+      ]
+    }
+  });
+  layout.appendChild(listEl);
+  return layout;
+}

--- a/app/static/js/windows/window_sessions.js
+++ b/app/static/js/windows/window_sessions.js
@@ -1,0 +1,17 @@
+import { el } from "../ui.js";
+import { createItemList } from "../components.js";
+
+export function render(config, winId) {
+  const layout = el("div", { class: "form" });
+  const listEl = createItemList(config.id || winId, {
+    id: "session_list",
+    item_template: {
+      elements: [
+        { type: "text", bind: "title", class: "li-title" },
+        { type: "text", bind: "created_at", class: "li-right" }
+      ]
+    }
+  });
+  layout.appendChild(listEl);
+  return layout;
+}


### PR DESCRIPTION
## Summary
- Move individual window renderers into dedicated modules under `app/static/js/windows`
- Register window renderer modules in `window.js`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a5adbffb0832cb7cc019b3653234b