### PR TITLE
feat: improve accessibility navigation and roles

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -50,6 +50,29 @@ html, body {
 
 .app { display: flex; flex-direction: column; height: 100%; }
 
+/* Skip link for keyboard navigation */
+.skip-link {
+  position: absolute;
+  left: -999px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  z-index: -100;
+}
+
+.skip-link:focus {
+  left: 1rem;
+  top: 1rem;
+  width: auto;
+  height: auto;
+  padding: 0.5rem 1rem;
+  background: var(--panel);
+  color: var(--text);
+  border-radius: 8px;
+  z-index: 1000;
+}
+
 /* ===== Header & Menu ===== */
 .app-header {
   padding: 8px 12px;

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -1,7 +1,7 @@
 // main.js — tiny glue after refactor
 import { initWindowDnD } from "./dnd.js";
 import { initSplitter } from "./splitter.js";
-import { createMiniWindowFromConfig, initWindowResize } from "./window.js";
+import { createMiniWindowFromConfig, initWindowResize, initWindowKeyboard } from "./window.js";
 import { windows } from "./ui/windows.js";
 import { initMenu } from "./menu.js";
 
@@ -21,6 +21,7 @@ import { Store } from "./ui/store.js";
 initSplitter();
 initWindowDnD();
 initWindowResize();
+initWindowKeyboard();
 
 // mount initial windows
 for (const w of windows) {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -8,6 +8,7 @@
   <link rel="icon" href="data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='12' fill='%231b2130'/%3E%3Cpath d='M16 40 L32 16 L48 40' stroke='%236aa8ff' stroke-width='6' fill='none' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E" />
 </head>
 <body>
+  <a href="#columns" class="skip-link">Skip to main content</a>
   <div class="app">
     <div class="app-header">
       <div class="brand"><strong>Deployable Knowledge v0.1 ᚼᚢᚴᛁᚾ:ᚬᚴ:ᛘᚢᚾᛁᚾ</strong></div>
@@ -31,7 +32,7 @@
       </div>
     </div>
 
-    <div class="columns" id="columns">
+    <div class="columns" id="columns" tabindex="-1">
       <div class="col" id="col-left"></div>
       <div class="splitter" id="splitter" role="separator" aria-orientation="vertical" aria-label="Resize Columns"></div>
       <div class="col" id="col-right"></div>

--- a/app/templates/splash.html
+++ b/app/templates/splash.html
@@ -7,12 +7,13 @@
   <link rel="icon" href="/static/favicon.ico" />
 </head>
 <body>
+  <a href="#splash-body" class="skip-link">Skip to main content</a>
   <div class="app">
     <div class="app-header">
       <div class="brand"><strong>Deployable Knowledge</strong></div>
       <div class="fill"></div>
     </div>
-    <div class="splash-body">
+    <div class="splash-body" id="splash-body" tabindex="-1">
       <div class="miniwin splash-card">
         <div class="titlebar"><div class="title">Welcome</div></div>
         <div class="content"><div class="content-inner">


### PR DESCRIPTION
## Summary
- add skip links and tabindex for main content navigation
- assign dialog roles to mini windows with labeled icon buttons
- enable keyboard focus/escape handling and modal focus traps

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a5ade1a54832cbb59046553f5fcb0