### PR TITLE
Add JS bundler and lint tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm install
+      - run: npm run lint
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - run: pip install -r requirements.txt
+      - run: pytest -q

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ build/
 env/
 venv/
 ENV/
+node_modules/
 *.env
 *.env.*
 
@@ -40,6 +41,7 @@ parsed_texts/
 # --- Query result data ---
 *.json
 !prompts/*.json
+!package.json
 
 # --- Model cache or sentence-transformers ---
 cache/

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,2 @@
+#!/bin/sh
+npm run lint

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,0 +1,2 @@
+dist
+node_modules

--- a/.stylelintrc.cjs
+++ b/.stylelintrc.cjs
@@ -1,0 +1,5 @@
+module.exports = {
+  rules: {
+    'block-no-empty': true
+  }
+};

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,13 @@
+export default [
+  {
+    ignores: ['dist', 'node_modules']
+  },
+  {
+    files: ['**/*.{js,jsx,ts,tsx}'],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module'
+    },
+    rules: {}
+  }
+];

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "deployable-knowledge",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite build --watch",
+    "build": "vite build",
+    "lint:js": "eslint \"**/*.{js,jsx,ts,tsx}\"",
+    "lint:css": "stylelint \"**/*.{css,scss}\" --allow-empty-input",
+    "lint": "npm run lint:js && npm run lint:css",
+    "prepare": "husky install"
+  },
+  "devDependencies": {
+    "eslint": "^8.57.0",
+    "husky": "^8.0.3",
+    "stylelint": "^15.11.0",
+    "vite": "^4.5.0"
+  }
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  build: {
+    minify: 'esbuild',
+    cssCodeSplit: true,
+    lib: {
+      entry: 'sandbox-js/test_main.js',
+      name: 'Sandbox',
+      fileName: 'bundle'
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- add package.json with Vite bundling and ESLint/Stylelint scripts
- enforce linting via pre-commit hook and GitHub Actions
- configure Vite build for minified library output

## Testing
- `npm run lint` *(fails: stylelint not found)*
- `npm run build` *(fails: vite: not found)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a5ae0834c832cacf7df9a79a41da0