### PR TITLE
feat: add tools menu and window interaction enhancements

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -16,11 +16,23 @@ html, body {
   padding: 8px 12px;
   background: linear-gradient(180deg, hsl(var(--h) var(--sat) calc(var(--l-panel) + 2%)), hsl(var(--h) var(--sat) var(--l-panel)));
   border-bottom: 1px solid var(--border);
-  display: grid; grid-template-columns: auto auto 1fr auto;
-  align-items: center; gap: 10px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  position: relative;
 }
-.brand { font-size: 14px; color: var(--muted); letter-spacing: .3px; }
-.fill { justify-self: end; }
+.app-header .left,
+.app-header .right { display: flex; align-items: center; gap: 10px; }
+.app-header .right { margin-left: auto; }
+.brand {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 14px;
+  color: var(--muted);
+  letter-spacing: .3px;
+}
+.runes { font-size: 14px; color: var(--muted); letter-spacing: .3px; }
 
 .menu { position: relative; }
 .menu-trigger {
@@ -239,8 +251,12 @@ html, body {
   min-height: 0;
 }
 .chat-window .chat-log {
-  display: grid; gap: 8px; padding: 8px;
-  border: 1px solid var(--border); border-radius: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 8px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
   background: hsl(var(--h) var(--sat) calc(var(--l-bg) + 2%));
   overflow: auto;
   flex: 1 1 auto;
@@ -266,6 +282,24 @@ html, body {
   outline-offset: -6px; background: color-mix(in oklab, var(--accent) 7%, transparent);
 }
 .miniwin.dragging { position: fixed; z-index: 9999; width: var(--drag-w); pointer-events: none; }
+
+.drop-marker {
+  height: 4px;
+  background: color-mix(in oklab, var(--accent) 60%, transparent);
+  border-radius: 2px;
+  margin: 4px 0;
+}
+
+.down-indicator {
+  position: sticky;
+  bottom: 4px;
+  text-align: center;
+  font-size: 20px;
+  pointer-events: none;
+  opacity: 1;
+  transition: opacity .3s ease;
+}
+.down-indicator.hide { opacity: 0; }
 
 /* ===== Modal ===== */
 .modal-wrap { position: fixed; inset: 0; display: grid; place-items: center; z-index: 1000; }

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -56,7 +56,7 @@ html, body {
 
 /* ===== Columns & Splitter ===== */
 .columns { position: relative; display: flex; flex: 1 1 auto; min-height: 0; overflow: hidden; }
-.col { flex: 1 1 50%; min-width: 200px; padding: 16px; overflow: auto; border-right: 1px solid var(--border); }
+.col { position: relative; flex: 1 1 50%; min-width: 200px; padding: 16px; overflow: auto; border-right: 1px solid var(--border); }
 .col:last-child { border-right: none; }
 
 /* Splitter — themed & interactive */
@@ -291,7 +291,9 @@ html, body {
 }
 
 .down-indicator {
-  position: sticky;
+  position: absolute;
+  left: 0;
+  right: 0;
   bottom: 4px;
   text-align: center;
   font-size: 20px;

--- a/app/static/js/dnd.js
+++ b/app/static/js/dnd.js
@@ -16,7 +16,7 @@ export function calcDragPosition(winStart, pointerStart, e) {
 
 export function handleDrop(draggingWin, isModalDrag, columnsEl, cols, e, getDropColumnAt, dropMarker) {
   if (!isModalDrag) {
-    const targetCol = getDropColumnAt(e.clientX, e.clientY);
+    const targetCol = dropMarker.parentNode || getDropColumnAt(e.clientX, e.clientY);
     cols.forEach(c => c.classList.remove("drop-candidate"));
     columnsEl.classList.remove("dragging");
 
@@ -28,12 +28,11 @@ export function handleDrop(draggingWin, isModalDrag, columnsEl, cols, e, getDrop
     draggingWin.style.width = "";
     draggingWin.style.pointerEvents = "";
 
-    if (dropMarker.parentNode) dropMarker.parentNode.removeChild(dropMarker);
-
     if (targetCol) {
       targetCol.insertBefore(draggingWin, dropMarker);
       draggingWin.focus({ preventScroll: true });
     }
+    if (dropMarker.parentNode) dropMarker.parentNode.removeChild(dropMarker);
   } else {
     draggingWin.classList.remove("dragging");
     draggingWin.style.removeProperty("--drag-w");

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -39,15 +39,17 @@ function spawnWindow(cfg, init) {
       indicator.className = "down-indicator";
       indicator.textContent = "⌄";
       colEl.appendChild(indicator);
-      const onScroll = () => {
-        if (colEl.scrollTop + colEl.clientHeight >= node.offsetTop) {
-          indicator.classList.add("hide");
-          setTimeout(() => indicator.remove(), 300);
-          colEl.removeEventListener("scroll", onScroll);
-        }
-      };
-      colEl.addEventListener("scroll", onScroll);
+    } else {
+      indicator.className = "down-indicator";
     }
+    const onScroll = () => {
+      if (colEl.scrollTop + colEl.clientHeight >= node.offsetTop) {
+        indicator.classList.add("hide");
+        setTimeout(() => indicator.remove(), 300);
+        colEl.removeEventListener("scroll", onScroll);
+      }
+    };
+    colEl.addEventListener("scroll", onScroll);
   }
   if (init) init(cfg.id);
   return node;

--- a/app/static/js/ui/windows.js
+++ b/app/static/js/ui/windows.js
@@ -1,9 +1,9 @@
 // ui/windows.js — initial window configs
 export const windows = [
-  { id: "win_docs",     window_type: "window_documents", title: "Document Library", col: "left"  },
-  { id: "win_sessions", window_type: "window_sessions",  title: "Chat History",     col: "left"  },
-  { id: "win_chat",     window_type: "window_chat_ui",   title: "Assistant Chat",   col: "right" },
-  { id: "win_segments", window_type: "window_segments",  title: "DB Segments",      col: "right" }
+  { id: "win_docs",     window_type: "window_documents", title: "Document Library", col: "left",  unique: true },
+  { id: "win_sessions", window_type: "window_sessions",  title: "Chat History",     col: "left",  unique: true },
+  { id: "win_chat",     window_type: "window_chat_ui",   title: "Assistant Chat",   col: "right", unique: true },
+  { id: "win_segments", window_type: "window_segments",  title: "DB Segments",      col: "right", unique: true }
 ];
 
 export const windowTypes = {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -11,24 +11,37 @@
 <body>
   <div class="app">
     <div class="app-header">
-      <div class="brand"><strong>Deployable Knowledge v0.1 ᚼᚢᚴᛁᚾ:ᚬᚴ:ᛘᚢᚾᛁᚾ</strong></div>
-      <div class="menu">
-        <button id="menu-trigger" class="menu-trigger" aria-haspopup="true" aria-expanded="false">Menu ▾</button>
-        <div id="menu-dropdown" class="menu-dropdown" role="menu" aria-hidden="true">
-          <button class="menu-item" data-action="new-chat" role="menuitem">New Chat</button>
-          <button class="menu-item" data-action="edit-persona" role="menuitem">Persona…</button>
-          <button class="menu-item" data-action="toggle-search" role="menuitem">Context</button>
-          <div class="menu-sep"></div>
-          <button class="menu-item" data-action="prompt-templates" role="menuitem">Prompt Templates</button>
-          <button class="menu-item" data-action="settings" role="menuitem">Settings…</button>
+      <div class="left">
+        <div class="menu">
+          <button id="menu-trigger" class="menu-trigger" aria-haspopup="true" aria-expanded="false">Menu ▾</button>
+          <div id="menu-dropdown" class="menu-dropdown" role="menu" aria-hidden="true">
+            <button class="menu-item" data-action="new-chat" role="menuitem">New Chat</button>
+            <button class="menu-item" data-action="edit-persona" role="menuitem">Persona…</button>
+            <button class="menu-item" data-action="toggle-search" role="menuitem">Context</button>
+            <div class="menu-sep"></div>
+            <button class="menu-item" data-action="prompt-templates" role="menuitem">Prompt Templates</button>
+            <button class="menu-item" data-action="settings" role="menuitem">Settings…</button>
+          </div>
+        </div>
+        <div class="menu tools-menu">
+          <button id="tools-menu-trigger" class="menu-trigger" aria-haspopup="true" aria-expanded="false">Tools ▾</button>
+          <div id="tools-menu-dropdown" class="menu-dropdown" role="menu" aria-hidden="true">
+            <button class="menu-item" data-action="tool-chat" role="menuitem">Chat Assistant</button>
+            <button class="menu-item" data-action="tool-docs" role="menuitem">Documents Library</button>
+            <button class="menu-item" data-action="tool-sessions" role="menuitem">Chat History</button>
+            <button class="menu-item" data-action="tool-segments" role="menuitem">DB Segments</button>
+          </div>
         </div>
       </div>
-      <div class="fill"></div>
-      <div class="menu user-menu">
-        <button id="user-menu-trigger" class="menu-trigger" aria-haspopup="true" aria-expanded="false">User ▾</button>
-        <div id="user-menu-dropdown" class="menu-dropdown" role="menu" aria-hidden="true">
-          <button class="menu-item" data-action="logout" role="menuitem">Log Out</button>
+      <div class="brand"><strong>Deployable Knowledge v0.1</strong></div>
+      <div class="right">
+        <div class="menu user-menu">
+          <button id="user-menu-trigger" class="menu-trigger" aria-haspopup="true" aria-expanded="false">User ▾</button>
+          <div id="user-menu-dropdown" class="menu-dropdown" role="menu" aria-hidden="true">
+            <button class="menu-item" data-action="logout" role="menuitem">Log Out</button>
+          </div>
         </div>
+        <div class="runes">ᚼᚢᚴᛁᚾ:ᚬᚴ:ᛘᚢᚾᛁᚾ</div>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- add Tools dropdown with quick access to Chat Assistant, Documents Library, Chat History and DB Segments
- center application title and relocate runes, plus unique window spawning with offscreen indicator
- improve window drag-and-drop feedback and prevent minimize flicker

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_689a77961870832cae7d00dcd1410706