### PR TITLE
Verify drop marker before inserting dragged window

### DIFF
--- a/app/static/js/dnd.js
+++ b/app/static/js/dnd.js
@@ -28,10 +28,14 @@ export function handleDrop(draggingWin, isModalDrag, columnsEl, cols, e, getDrop
     draggingWin.style.width = "";
     draggingWin.style.pointerEvents = "";
     if (targetCol) {
-      targetCol.insertBefore(draggingWin, dropMarker);
+      if (dropMarker.parentNode === targetCol) {
+        targetCol.insertBefore(draggingWin, dropMarker);
+      } else {
+        targetCol.appendChild(draggingWin);
+      }
+      if (dropMarker.parentNode) dropMarker.parentNode.removeChild(dropMarker);
       draggingWin.focus({ preventScroll: true });
     }
-    if (dropMarker.parentNode) dropMarker.parentNode.removeChild(dropMarker);
   } else {
     draggingWin.classList.remove("dragging");
     draggingWin.style.removeProperty("--drag-w");


### PR DESCRIPTION
## Summary
- Safeguard window drop handling by verifying drop marker's parent matches target column
- Append to target column when no valid drop marker is present and remove marker after insertion

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ab773ff48832ca147dd637c225d0c