### PR TITLE
docs: expand UI guide and add version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Deployable-Knowledge
 
+**Version 0.9.0**
+
 Offline‑first retrieval‑augmented generation (RAG) stack for disconnected or bandwidth‑constrained environments.
 
 ## Overview

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,0 +1,4 @@
+"""Core utilities for Deployable Knowledge."""
+
+__version__ = "0.9.0"
+

--- a/docs/UI_OVERVIEW.md
+++ b/docs/UI_OVERVIEW.md
@@ -1,11 +1,53 @@
 # UI Overview
 
-The web UI served from `/` provides:
+The web interface served from `/` lets you interact with the local RAG stack without writing any backend code.
 
-- **Chat panel** – interactive conversation with streaming updates.
-- **Search bar** – perform document searches in a modal.
-- **Documents view** – list of uploaded sources with segment counts.
-- **Persona editor** – adjust assistant behaviour per session.
+## Getting Started
+Open `http://localhost:8000` after launching the server. A session is created automatically and the UI is split into chat, search, document management and persona panes.
+
+## Chat Panel
+The chat panel streams model responses as you type. Messages are sent through the `DKClient` SDK:
+
+```js
+import { dkClient } from "./ui/sdk/sdk.js";
+const sessionId = await dkClient.getOrCreateChatSession();
+const reply = await dkClient.chat({
+  message: "Summarise the uploaded notes",
+  session_id: sessionId
+});
+console.log(reply.response);
+```
+
+Use `streamChat` for incremental updates during longer generations.
+
+## Search Modal
+Press `/` or click the search bar to open the search modal. Results are returned from the local vector store.
+
+```js
+const hits = await dkClient.search("battery storage", 3);
+console.log(hits.results);
+```
+
+## Documents View
+The documents panel lists every ingested source and the number of vector segments it contains.
+
+```js
+// Upload a file selected from an `<input type="file">`
+await dkClient.uploadDocuments(input.files);
+// Fetch all stored documents
+const docs = await dkClient.listDocuments();
+```
+
+Documents can be removed via the UI or with `dkClient.removeDocument(name)`.
+
+## Persona Editor
+Each chat session can have a persona – short instructions that condition the assistant. Edit the persona text and new replies will adopt the updated tone or role.
+
+## Example Workflow
+1. Upload PDFs or markdown files.
+2. Ask questions in the chat panel.
+3. Use the search modal to inspect relevant passages.
+4. Refine behaviour via the persona editor.
 
 JavaScript modules under `app/static/js/` implement these features and communicate with the API via the `DKClient` SDK.
 


### PR DESCRIPTION
## Summary
- document web UI features with usage examples
- expose library version and mark README as version 0.9.0

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689bc80cb658832c905646d9cdb9665d