### PR TITLE
Refactor web UI and add auth and history

### DIFF
--- a/app/static/app/js/main.js
+++ b/app/static/app/js/main.js
@@ -59,6 +59,7 @@ function setupMenus(chatUI) {
       if (act === 'tool-segments') document.getElementById('win_segments')?.scrollIntoView();
       if (act === 'tool-sessions') openSessionsWindow();
       if (act === 'tool-persona') openPersonaEditor();
+      if (act === 'tool-refresh') { refreshDocs(); refreshSegments(); }
     });
   });
 

--- a/app/static/app/js/main.js
+++ b/app/static/app/js/main.js
@@ -1,20 +1,15 @@
 // /app/main.js
-import { initFramework, spawnWindow } from "./framework.js";
-import { bus, getComponent } from "/static/ui/js/components.js";
-import {
-  listDocuments, uploadDocuments, removeDocument,
-  listSegments, getSegment, removeSegment,
-  chat, chatStream, searchSegments
-} from "./sdk.js";
+import { initFramework } from "./framework.js";
+import { bus } from "/static/ui/js/components.js";
 import { Store } from "./store.js";
+import { createChatWindow } from "./windows/chat.js";
+import { createDocsWindow, refreshDocs, handleDocAction } from "./windows/docs.js";
+import { createSegmentsWindow, refreshSegments, handleSegmentAction, setSegmentsSource, openSegmentViewer } from "./windows/segments.js";
+import { createSearchWindow } from "./windows/search.js";
+import { openSessionsWindow, loadChatHistory } from "./windows/sessions.js";
+import { openPersonaEditor } from "./windows/persona.js";
 
 initFramework();
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-const htmlEscape = (s="") => s.replaceAll("&","&amp;").replaceAll("<","&lt;").replaceAll(">","&gt;");
-const md = (s="") => (window.marked?.parse ? window.marked.parse(s) : htmlEscape(s).replaceAll("\n","<br>"));
 
 async function ensureChatSession() {
   try {
@@ -26,339 +21,6 @@ async function ensureChatSession() {
   }
 }
 
-// ---------------------------------------------------------------------------
-// Windows
-// ---------------------------------------------------------------------------
-async function openSegmentViewer(id) {
-  const seg = await getSegment(id);
-  const winId = `seg_view_${id}`;
-  spawnWindow({
-    id: winId,
-    window_type: "window_generic",
-    title: seg?.source ? `Segment • ${seg.source}` : "Segment",
-    col: "right",
-    unique: false,
-    resizable: true,
-    Elements: [
-      { type: "text", id: "seg_meta", value: "" },
-      { type: "note", id: "seg_text", text: "" }
-    ]
-  });
-  const win = document.getElementById(winId);
-  const meta = win?.querySelector("#seg_meta")?.closest(".row")?.querySelector(".value") || win?.querySelector("#seg_meta");
-  const bodyRow = win?.querySelector("#seg_text")?.closest(".row");
-  if (meta) {
-    meta.innerHTML = `
-      <div class="kv">
-        <div><strong>ID:</strong> ${htmlEscape(seg.id||"")}</div>
-        <div><strong>Source:</strong> ${htmlEscape(seg.source||"")}</div>
-        <div><strong>Index:</strong> ${htmlEscape(String(seg.segment_index ?? ""))}</div>
-        <div><strong>Priority:</strong> ${htmlEscape(seg.priority||"")}</div>
-        <div><strong>Chars:</strong> ${htmlEscape(String(seg.start_char ?? ""))}–${htmlEscape(String(seg.end_char ?? ""))}</div>
-      </div>`;
-  }
-  if (bodyRow) {
-    const viewer = document.createElement("div");
-    viewer.className = "segment-view prose";
-    viewer.innerHTML = md(seg.text || seg.preview || "(empty)");
-    bodyRow.replaceWith(viewer);
-  }
-}
-
-function createSearchWindow() {
-  spawnWindow({
-    id: "win_search",
-    window_type: "window_generic",
-    title: "Semantic Search",
-    col: "right",
-    unique: true,
-    resizable: true,
-    Elements: [
-      { type: "text_field",  id: "search_q", placeholder: "Search text…" },
-      { type: "number_field", id: "search_k", label: "Top K", value: 10, min: 1, max: 100 },
-      {
-        type: "item_list",
-        id: "search_results",
-        label: "Results",
-        item_template: {
-          elements: [
-            { type: "text", bind: "source",  class: "li-title"  },
-            { type: "text", bind: "preview", class: "li-subtle" },
-            { type: "button", label: "Open", action: "open" }
-          ]
-        }
-      }
-    ]
-  });
-  const win = document.getElementById("win_search");
-  const qInput = win?.querySelector("#search_q");
-  const kInput = win?.querySelector("#search_k") || { value: 10 };
-  if (qInput) {
-    const qRow = qInput.closest(".row");
-    const bar  = document.createElement("div");
-    bar.className = "actions";
-    const btn  = document.createElement("button");
-    btn.type = "button"; btn.className = "btn"; btn.id = "search_btn"; btn.textContent = "Search";
-    bar.appendChild(btn);
-    qRow?.after(bar);
-    async function runSearch() {
-      const q = qInput.value.trim();
-      const k = parseInt(kInput.value || "10", 10);
-      if (!q) return;
-      const inactive = Store?.inactiveList?.() || [];
-      const res = await searchSegments({ q, top_k: k, inactive });
-      const results = Array.isArray(res?.results) ? res.results : (Array.isArray(res) ? res : []);
-      const comp = getComponent("win_search", "search_results");
-      comp?.render(results);
-    }
-    btn.addEventListener("click", runSearch);
-    qInput.addEventListener("keydown", (e) => { if (e.key === "Enter") runSearch(); });
-  }
-}
-
-async function refreshDocs() {
-  const data = await listDocuments();
-  const docs = (data || []).map(d => ({ ...d, active: Store.isDocActive(d.id) }));
-  const comp = getComponent("win_docs", "doc_list");
-  comp?.render(docs);
-}
-async function handleUpload(files) {
-  if (!files || !files.length) return;
-  await uploadDocuments(files);
-  document.getElementById("docs_upload")?.clear?.();
-  await refreshDocs();
-}
-function createDocsWindow() {
-  spawnWindow({
-    id: "win_docs",
-    window_type: "window_generic",
-    title: "Document Library",
-    col: "left",
-    unique: true,
-    resizable: true,
-    Elements: [
-      {
-        type: "file_upload",
-        id: "docs_upload",
-        multiple: true,
-        selectLabel: "Choose Files",
-        buttonLabel: "Upload",
-        onUpload: handleUpload,
-      },
-      {
-        type: "item_list",
-        id: "doc_list",
-        label: "Documents",
-        item_template: {
-          elements: [
-            { type: "text", bind: "title",   class: "li-title" },
-            { type: "text", bind: "segments", class: "li-meta" },
-            { type: "button", toggle: { prop: "active", on: "Deactivate", off: "Activate", action: "toggle_active" } },
-            { type: "button", label: "Remove", action: "remove", variant: "danger" }
-          ]
-        }
-      }
-    ]
-  });
-}
-
-let currentSource = null;
-async function refreshSegments() {
-  const segs = await listSegments(currentSource);
-  const comp = getComponent("win_segments", "segment_list");
-  comp?.render(segs || []);
-}
-function createSegmentsWindow() {
-  spawnWindow({
-    id: "win_segments",
-    window_type: "window_generic",
-    title: "DB Segments",
-    col: "right",
-    unique: true,
-    resizable: true,
-    Elements: [
-      {
-        type: "item_list",
-        id: "segment_list",
-        label: "Segments",
-        item_template: {
-          elements: [
-            { type: "text", bind: "source",  class: "li-title"  },
-            { type: "text", bind: "priority", class: "li-meta"  },
-            { type: "text", bind: "preview",  class: "li-subtle" },
-            { type: "button", label: "Open",   action: "open"    },
-            { type: "button", label: "Remove", action: "remove", variant: "danger" }
-          ]
-        }
-      }
-    ]
-  });
-}
-
-function createChatWindow() {
-  spawnWindow({
-    id: "win_chat",
-    window_type: "window_generic",
-    title: "Assistant Chat",
-    col: "right",
-    unique: true,
-    resizable: true,
-    Elements: [
-      { type: "text_area",  id: "chat_log",   rows: 14, value: "" },
-      { type: "text_field", id: "chat_input", placeholder: "Type a message…" }
-    ]
-  });
-  const win   = document.getElementById("win_chat");
-  const taRow = win?.querySelector("#chat_log")?.closest(".row");
-  if (!win || !taRow) return {};
-  const log = document.createElement("div");
-  log.id = "chat_log"; log.className = "chat-log";
-  taRow.replaceWith(log);
-  const input    = win.querySelector("#chat_input");
-  const inputRow = input?.closest(".row");
-  const bar      = document.createElement("div");
-  bar.className  = "chat-input";
-  const btn      = document.createElement("button");
-  btn.type = "button"; btn.className = "btn"; btn.textContent = "Send";
-  inputRow?.replaceWith(bar);
-  bar.append(input, btn);
-  const pushUser = (text) => {
-    const d = document.createElement("div");
-    d.className = "msg you"; d.innerHTML = "You: " + htmlEscape(text);
-    log.appendChild(d); log.scrollTop = log.scrollHeight;
-  };
-  const pushAssistant = () => {
-    const d = document.createElement("div");
-    d.className = "msg assistant"; d.innerHTML = "…";
-    log.appendChild(d); log.scrollTop = log.scrollHeight; return d;
-  };
-  async function send() {
-    const text = input.value.trim();
-    if (!text) return;
-    input.value = ""; pushUser(text); const bubble = pushAssistant();
-    try {
-      const { reader, decoder } = await chatStream({
-        message: text,
-        session_id: (Store.sessionId || "") + "",
-        persona: Store.persona || "",
-        inactive: Store.inactiveList?.() || [],
-      });
-      let buf = "";
-      while (true) {
-        const { value, done } = await reader.read();
-        if (done) break;
-        buf += decoder.decode(value, { stream: true });
-        const chunks = buf.split("\n\n");
-        buf = chunks.pop();
-        for (const chunk of chunks) {
-          let event = "delta", data = "";
-          for (const line of chunk.split("\n")) {
-            if (line.startsWith("event:")) event = line.slice(6).trim();
-            else if (line.startsWith("data:")) data += line.slice(5).trim();
-          }
-          if (event === "delta") {
-            try { data = JSON.parse(data); } catch {}
-            if (data === ".") continue; // ignore keep-alives
-            bubble._acc = (bubble._acc || "") + data;
-            bubble.innerHTML = md(bubble._acc);
-          }
-        }
-        log.scrollTop = log.scrollHeight;
-      }
-    } catch {
-      try {
-        const res = await chat({
-          message: text,
-          session_id: (Store.sessionId || "") + "",
-          persona: Store.persona || "",
-          inactive: Store.inactiveList?.() || [],
-        });
-        bubble.innerHTML = md(res.response ?? "(no response)");
-      } catch (e2) {
-        bubble.innerHTML = `<em>Error:</em> ${htmlEscape(e2.message)}`;
-      }
-    }
-  }
-  btn.addEventListener("click", send);
-  input.addEventListener("keydown", (e) => { if (e.key === "Enter") send(); });
-  return { log, pushUser, pushAssistant };
-}
-
-// ---------------------------------------------------------------------------
-// Chat History & Persona Editor
-// ---------------------------------------------------------------------------
-async function refreshSessions() {
-  const res = await fetch("/sessions", { credentials: "same-origin" });
-  const data = await res.json();
-  const comp = getComponent("win_sessions", "session_list");
-  comp?.render(data);
-}
-async function openSessionsWindow() {
-  if (!document.getElementById("win_sessions")) {
-    spawnWindow({
-      id: "win_sessions",
-      window_type: "window_generic",
-      title: "Chat History",
-      col: "left",
-      unique: true,
-      resizable: true,
-      Elements: [
-        {
-          type: "item_list",
-          id: "session_list",
-          label: "Sessions",
-          item_template: {
-            elements: [
-              { type: "text", bind: "title", class: "li-title" },
-              { type: "text", bind: "created_at", class: "li-meta" },
-              { type: "button", label: "Open", action: "open" }
-            ]
-          }
-        }
-      ]
-    });
-  }
-  await refreshSessions();
-}
-async function loadChatHistory(id) {
-  if (!id) return;
-  try {
-    const res = await fetch(`/sessions/${encodeURIComponent(id)}`, { credentials: "same-origin" });
-    if (!res.ok) return;
-    const data = await res.json();
-    chatUI.log.innerHTML = "";
-    for (const [user, assistant] of data.history || []) {
-      chatUI.pushUser(user);
-      const b = chatUI.pushAssistant();
-      b.innerHTML = md(assistant || "");
-    }
-  } catch {}
-}
-function openPersonaEditor() {
-  if (document.getElementById("modal_persona")) return;
-  spawnWindow({
-    id: "modal_persona",
-    window_type: "window_generic",
-    title: "Persona",
-    modal: true,
-    unique: true,
-    resizable: false,
-    Elements: [
-      { type: "text_area", id: "persona_text", rows: 6, value: Store.persona || "" },
-      { type: "button", id: "persona_save", label: "Save" }
-    ]
-  });
-  const modal = document.getElementById("modal_persona");
-  modal.querySelector("#persona_save")?.addEventListener("click", () => {
-    const val = modal.querySelector("#persona_text")?.value || "";
-    Store.persona = val;
-    modal.remove();
-  });
-}
-
-// ---------------------------------------------------------------------------
-// Menu & Bus wiring
-// ---------------------------------------------------------------------------
 function setupMenus() {
   document.querySelector('#user-menu-dropdown [data-action="logout"]')?.addEventListener('click', () => {
     window.location.href = '/logout';
@@ -379,33 +41,28 @@ function registerBusHandlers() {
   bus.addEventListener("ui:list-action", async (ev) => {
     const { winId, elementId, action, item } = ev.detail || {};
     if (winId === "win_docs" && elementId === "doc_list") {
-      if (action === "toggle_active") { Store.toggleDoc(item.id); await refreshDocs(); }
-      if (action === "remove")        { try { await removeDocument(item.id); } finally { await refreshDocs(); } }
+      await handleDocAction(action, item);
     }
     if (winId === "win_segments" && elementId === "segment_list") {
-      if (action === "open")   await openSegmentViewer(item.id);
-      if (action === "remove") { try { await removeSegment(item.id); } finally { await refreshSegments(); } }
+      await handleSegmentAction(action, item);
     }
     if (winId === "win_search" && elementId === "search_results" && action === "open" && item?.id) {
       await openSegmentViewer(item.id);
     }
     if (winId === "win_sessions" && elementId === "session_list" && action === "open" && item?.session_id) {
       Store.sessionId = item.session_id;
-      await loadChatHistory(Store.sessionId);
+      await loadChatHistory(chatUI, Store.sessionId);
     }
   });
   bus.addEventListener("ui:list-select", async (ev) => {
     const { winId, elementId, item } = ev.detail || {};
     if (winId === "win_docs" && elementId === "doc_list") {
-      currentSource = item?.id || null;
+      setSegmentsSource(item?.id);
       await refreshSegments();
     }
   });
 }
 
-// ---------------------------------------------------------------------------
-// Bootstrap
-// ---------------------------------------------------------------------------
 await ensureChatSession();
 const chatUI = createChatWindow();
 createSearchWindow();
@@ -415,4 +72,4 @@ setupMenus();
 registerBusHandlers();
 await refreshDocs();
 await refreshSegments();
-await loadChatHistory(Store.sessionId);
+await loadChatHistory(chatUI, Store.sessionId);

--- a/app/static/app/js/main.js
+++ b/app/static/app/js/main.js
@@ -3,23 +3,35 @@ import { initFramework, spawnWindow } from "./framework.js";
 import { bus, getComponent } from "/static/ui/js/components.js";
 import {
   listDocuments, uploadDocuments, removeDocument,
-  listSegments, getSegment, removeSegment, chat, chatStream, searchSegments
+  listSegments, getSegment, removeSegment,
+  chat, chatStream, searchSegments
 } from "./sdk.js";
 import { Store } from "./store.js";
 
-initFramework(); // splitter + dnd + resizer
+initFramework();
 
-
-
-// === ADD helpers ===
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
 const htmlEscape = (s="") => s.replaceAll("&","&amp;").replaceAll("<","&lt;").replaceAll(">","&gt;");
-const renderMd = (s="") => (window.marked?.parse ? window.marked.parse(s) : htmlEscape(s).replaceAll("\n","<br>"));
+const md = (s="") => (window.marked?.parse ? window.marked.parse(s) : htmlEscape(s).replaceAll("\n","<br>"));
 
-// spawn a Segment Viewer window and render payload
+async function ensureChatSession() {
+  try {
+    const res = await fetch("/session", { credentials: "same-origin" });
+    const data = await res.json();
+    Store.sessionId = data.session_id;
+  } catch (e) {
+    console.error("session", e);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Windows
+// ---------------------------------------------------------------------------
 async function openSegmentViewer(id) {
   const seg = await getSegment(id);
   const winId = `seg_view_${id}`;
-  // create the window shell
   spawnWindow({
     id: winId,
     window_type: "window_generic",
@@ -29,11 +41,9 @@ async function openSegmentViewer(id) {
     resizable: true,
     Elements: [
       { type: "text", id: "seg_meta", value: "" },
-      { type: "note", id: "seg_text", text: "" } // we'll overwrite as HTML
+      { type: "note", id: "seg_text", text: "" }
     ]
   });
-
-  // render metadata + body
   const win = document.getElementById(winId);
   const meta = win?.querySelector("#seg_meta")?.closest(".row")?.querySelector(".value") || win?.querySelector("#seg_meta");
   const bodyRow = win?.querySelector("#seg_text")?.closest(".row");
@@ -45,60 +55,52 @@ async function openSegmentViewer(id) {
         <div><strong>Index:</strong> ${htmlEscape(String(seg.segment_index ?? ""))}</div>
         <div><strong>Priority:</strong> ${htmlEscape(seg.priority||"")}</div>
         <div><strong>Chars:</strong> ${htmlEscape(String(seg.start_char ?? ""))}–${htmlEscape(String(seg.end_char ?? ""))}</div>
-      </div>
-    `;
+      </div>`;
   }
   if (bodyRow) {
     const viewer = document.createElement("div");
     viewer.className = "segment-view prose";
-    viewer.innerHTML = renderMd(seg.text || seg.preview || "(empty)");
+    viewer.innerHTML = md(seg.text || seg.preview || "(empty)");
     bodyRow.replaceWith(viewer);
   }
 }
-// === REPLACE your current Search window spawn block ===
-spawnWindow({
-  id: "win_search",
-  window_type: "window_generic",
-  title: "Semantic Search",
-  col: "right",
-  unique: true,
-  resizable: true,
-  Elements: [
-    { type: "text_field",  id: "search_q", placeholder: "Search text…" },
-    { type: "number_field", id: "search_k", label: "Top K", value: 10, min: 1, max: 100 },
-    {
-      type: "item_list",
-      id: "search_results",
-      label: "Results",
-      item_template: {
-        elements: [
-          { type: "text", bind: "source",  class: "li-title"  },
-          { type: "text", bind: "preview", class: "li-subtle" },
-          { type: "button", label: "Open", action: "open" } // buttons are allowed here
-        ]
+
+function createSearchWindow() {
+  spawnWindow({
+    id: "win_search",
+    window_type: "window_generic",
+    title: "Semantic Search",
+    col: "right",
+    unique: true,
+    resizable: true,
+    Elements: [
+      { type: "text_field",  id: "search_q", placeholder: "Search text…" },
+      { type: "number_field", id: "search_k", label: "Top K", value: 10, min: 1, max: 100 },
+      {
+        type: "item_list",
+        id: "search_results",
+        label: "Results",
+        item_template: {
+          elements: [
+            { type: "text", bind: "source",  class: "li-title"  },
+            { type: "text", bind: "preview", class: "li-subtle" },
+            { type: "button", label: "Open", action: "open" }
+          ]
+        }
       }
-    }
-  ]
-});
-// === ADD right after the spawnWindow(...) above ===
-{
+    ]
+  });
   const win = document.getElementById("win_search");
   const qInput = win?.querySelector("#search_q");
   const kInput = win?.querySelector("#search_k") || { value: 10 };
-
   if (qInput) {
-    // build a tiny action bar under the query field
     const qRow = qInput.closest(".row");
     const bar  = document.createElement("div");
     bar.className = "actions";
     const btn  = document.createElement("button");
-    btn.type = "button";
-    btn.className = "btn";
-    btn.id = "search_btn";
-    btn.textContent = "Search";
+    btn.type = "button"; btn.className = "btn"; btn.id = "search_btn"; btn.textContent = "Search";
     bar.appendChild(btn);
     qRow?.after(bar);
-
     async function runSearch() {
       const q = qInput.value.trim();
       const k = parseInt(kInput.value || "10", 10);
@@ -109,270 +111,303 @@ spawnWindow({
       const comp = getComponent("win_search", "search_results");
       comp?.render(results);
     }
-
     btn.addEventListener("click", runSearch);
     qInput.addEventListener("keydown", (e) => { if (e.key === "Enter") runSearch(); });
   }
 }
 
-
-// --- chat helpers ---
-const escapeHtml = (s="") => s.replaceAll("&","&amp;").replaceAll("<","&lt;").replaceAll(">","&gt;");
-const md = (s="") => (window.marked?.parse ? window.marked.parse(s) : escapeHtml(s).replaceAll("\n","<br>"));
-
-// --- spawn Chat window ---
-spawnWindow({
-  id: "win_chat",
-  window_type: "window_generic",   // no window_chat_ui in this framework
-  title: "Assistant Chat",
-  col: "right",
-  unique: true,
-  resizable: true,
-  Elements: [
-    { type: "text_area",  id: "chat_log",   rows: 14, value: "" },
-    { type: "text_field", id: "chat_input", placeholder: "Type a message…" }
-  ]
-});
-
-
-// ── Document Library helpers ──────────────────────────────────────────────
 async function refreshDocs() {
   const data = await listDocuments();
   const docs = (data || []).map(d => ({ ...d, active: Store.isDocActive(d.id) }));
   const comp = getComponent("win_docs", "doc_list");
   comp?.render(docs);
 }
-
 async function handleUpload(files) {
   if (!files || !files.length) return;
   await uploadDocuments(files);
   document.getElementById("docs_upload")?.clear?.();
   await refreshDocs();
 }
+function createDocsWindow() {
+  spawnWindow({
+    id: "win_docs",
+    window_type: "window_generic",
+    title: "Document Library",
+    col: "left",
+    unique: true,
+    resizable: true,
+    Elements: [
+      {
+        type: "file_upload",
+        id: "docs_upload",
+        multiple: true,
+        selectLabel: "Choose Files",
+        buttonLabel: "Upload",
+        onUpload: handleUpload,
+      },
+      {
+        type: "item_list",
+        id: "doc_list",
+        label: "Documents",
+        item_template: {
+          elements: [
+            { type: "text", bind: "title",   class: "li-title" },
+            { type: "text", bind: "segments", class: "li-meta" },
+            { type: "button", toggle: { prop: "active", on: "Deactivate", off: "Activate", action: "toggle_active" } },
+            { type: "button", label: "Remove", action: "remove", variant: "danger" }
+          ]
+        }
+      }
+    ]
+  });
+}
 
-// ── Segments helpers ──────────────────────────────────────────────────────
-let currentSource = null; // when you click a doc, we filter segments by its id/source
-
+let currentSource = null;
 async function refreshSegments() {
   const segs = await listSegments(currentSource);
   const comp = getComponent("win_segments", "segment_list");
   comp?.render(segs || []);
 }
-
-async function openSegment(id) {
-  const data = await getSegment(id);
-  if (!data) return;
+function createSegmentsWindow() {
   spawnWindow({
-    id: `seg_${id}`,
-    window_type: "window_segment_view",
-    title: data.source || "Segment",
+    id: "win_segments",
+    window_type: "window_generic",
+    title: "DB Segments",
     col: "right",
-    unique: false,
-    segment: data
+    unique: true,
+    resizable: true,
+    Elements: [
+      {
+        type: "item_list",
+        id: "segment_list",
+        label: "Segments",
+        item_template: {
+          elements: [
+            { type: "text", bind: "source",  class: "li-title"  },
+            { type: "text", bind: "priority", class: "li-meta"  },
+            { type: "text", bind: "preview",  class: "li-subtle" },
+            { type: "button", label: "Open",   action: "open"    },
+            { type: "button", label: "Remove", action: "remove", variant: "danger" }
+          ]
+        }
+      }
+    ]
   });
 }
 
-// ── Spawn windows ─────────────────────────────────────────────────────────
-spawnWindow({
-  id: "win_docs",
-  window_type: "window_generic",
-  title: "Document Library",
-  col: "left",
-  unique: true,
-  resizable: true,
-  Elements: [
-    {
-      type: "file_upload",
-      id: "docs_upload",
-      multiple: true,
-      selectLabel: "Choose Files",
-      buttonLabel: "Upload",
-      onUpload: handleUpload,
-    },
-    {
-      type: "item_list",
-      id: "doc_list",
-      label: "Documents",
-      item_template: {
-        elements: [
-          { type: "text", bind: "title",   class: "li-title" },
-          { type: "text", bind: "segments", class: "li-meta" },
-          { type: "button", toggle: { prop: "active", on: "Deactivate", off: "Activate", action: "toggle_active" } },
-          { type: "button", label: "Remove", action: "remove", variant: "danger" }
-        ]
-      }
-    }
-  ]
-});
-
-// replace the segments spawn block
-spawnWindow({
-  id: "win_segments",
-  window_type: "window_generic",   // <- was "window_segments"
-  title: "DB Segments",
-  col: "right",
-  unique: true,
-  resizable: true,
-  Elements: [
-    {
-      type: "item_list",
-      id: "segment_list",
-      label: "Segments",
-      item_template: {
-        elements: [
-          { type: "text", bind: "source",  class: "li-title"  },
-          { type: "text", bind: "priority", class: "li-meta"  },
-          { type: "text", bind: "preview",  class: "li-subtle" },
-          { type: "button", label: "Open",   action: "open"    },
-          { type: "button", label: "Remove", action: "remove", variant: "danger" }
-        ]
-      }
-    }
-  ]
-});
-
-// ── Bus wiring ────────────────────────────────────────────────────────────
-// Docs list row actions
-bus.addEventListener("ui:list-action", async (ev) => {
-  const { winId, elementId, action, item } = ev.detail || {};
-  if (winId === "win_docs" && elementId === "doc_list") {
-    if (action === "toggle_active") { Store.toggleDoc(item.id); await refreshDocs(); }
-    if (action === "remove")        { try { await removeDocument(item.id); } finally { await refreshDocs(); } }
-  }
-});
-
-// Docs list row selection -> filter Segments
-bus.addEventListener("ui:list-select", async (ev) => {
-  const { winId, elementId, item } = ev.detail || {};
-  if (winId === "win_docs" && elementId === "doc_list") {
-    currentSource = item?.id || null;   // you might prefer item.source depending on your backend
-    await refreshSegments();
-  }
-});
-
-// Segment list actions
-bus.addEventListener("ui:list-action", async (ev) => {
-  const { winId, elementId, action, item } = ev.detail || {};
-  if (winId === "win_segments" && elementId === "segment_list") {
-    if (action === "open")   await openSegment(item.id);
-    if (action === "remove") { try { await removeSegment(item.id); } finally { await refreshSegments(); } }
-  }
-});
-
-// --- chat wiring (generic window -> proper chat) ---
-{
+function createChatWindow() {
+  spawnWindow({
+    id: "win_chat",
+    window_type: "window_generic",
+    title: "Assistant Chat",
+    col: "right",
+    unique: true,
+    resizable: true,
+    Elements: [
+      { type: "text_area",  id: "chat_log",   rows: 14, value: "" },
+      { type: "text_field", id: "chat_input", placeholder: "Type a message…" }
+    ]
+  });
   const win   = document.getElementById("win_chat");
   const taRow = win?.querySelector("#chat_log")?.closest(".row");
-  if (!win || !taRow) { /* window not mounted */ }
-  else {
-    // upgrade textarea to a div.log
-    const log = document.createElement("div");
-    log.id = "chat_log";
-    log.className = "chat-log";
-    taRow.replaceWith(log);
-
-    // move input into a bar + add Send button
-    const input    = win.querySelector("#chat_input");
-    const inputRow = input?.closest(".row");
-    const bar      = document.createElement("div");
-    bar.className  = "chat-input";
-    const btn      = document.createElement("button");
-    btn.type = "button"; btn.className = "btn"; btn.textContent = "Send";
-    if (inputRow) inputRow.replaceWith(bar);
-    bar.append(input, btn);
-
-    // helpers
-    const escapeHtml = (s="") => s.replaceAll("&","&amp;").replaceAll("<","&lt;").replaceAll(">","&gt;");
-    const md = (s="") => (window.marked?.parse ? window.marked.parse(s) : escapeHtml(s).replaceAll("\n","<br>"));
-    const pushUser = (text) => {
-      const d = document.createElement("div");
-      d.className = "msg you";
-      d.innerHTML = "You: " + escapeHtml(text);
-      log.appendChild(d); log.scrollTop = log.scrollHeight;
-    };
-    const pushAssistant = () => {
-      const d = document.createElement("div");
-      d.className = "msg assistant";
-      d.innerHTML = "…";
-      log.appendChild(d); log.scrollTop = log.scrollHeight;
-      return d;
-    };
-
-    async function send() {
-      const text = input.value.trim();
-      if (!text) return;
-      input.value = "";
-      pushUser(text);
-      const bubble = pushAssistant();
-
-      // try streaming first; fallback to non-stream
-      try {
-        const { reader, decoder } = await chatStream({
-          message: text,
-          session_id: (Store?.sessionId ?? "") + "",
-          persona: Store?.persona || "",
-          inactive: Store?.inactiveList?.() || [],
-        });
-        let buf = "";
-        while (true) {
-          const { value, done } = await reader.read();
-          if (done) break;
-          buf += decoder.decode(value, { stream: true });
-          const chunks = buf.split("\n\n");  // naive SSE framing
-          buf = chunks.pop();
-          for (const chunk of chunks) {
-            let event = "delta", data = "";
-            for (const line of chunk.split("\n")) {
-              if (line.startsWith("event:")) event = line.slice(6).trim();
-              else if (line.startsWith("data:")) data += line.slice(5).trim();
-            }
-            if (event === "delta") bubble.innerHTML = md((bubble._acc ||= "") + data);
+  if (!win || !taRow) return {};
+  const log = document.createElement("div");
+  log.id = "chat_log"; log.className = "chat-log";
+  taRow.replaceWith(log);
+  const input    = win.querySelector("#chat_input");
+  const inputRow = input?.closest(".row");
+  const bar      = document.createElement("div");
+  bar.className  = "chat-input";
+  const btn      = document.createElement("button");
+  btn.type = "button"; btn.className = "btn"; btn.textContent = "Send";
+  inputRow?.replaceWith(bar);
+  bar.append(input, btn);
+  const pushUser = (text) => {
+    const d = document.createElement("div");
+    d.className = "msg you"; d.innerHTML = "You: " + htmlEscape(text);
+    log.appendChild(d); log.scrollTop = log.scrollHeight;
+  };
+  const pushAssistant = () => {
+    const d = document.createElement("div");
+    d.className = "msg assistant"; d.innerHTML = "…";
+    log.appendChild(d); log.scrollTop = log.scrollHeight; return d;
+  };
+  async function send() {
+    const text = input.value.trim();
+    if (!text) return;
+    input.value = ""; pushUser(text); const bubble = pushAssistant();
+    try {
+      const { reader, decoder } = await chatStream({
+        message: text,
+        session_id: (Store.sessionId || "") + "",
+        persona: Store.persona || "",
+        inactive: Store.inactiveList?.() || [],
+      });
+      let buf = "";
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buf += decoder.decode(value, { stream: true });
+        const chunks = buf.split("\n\n");
+        buf = chunks.pop();
+        for (const chunk of chunks) {
+          let event = "delta", data = "";
+          for (const line of chunk.split("\n")) {
+            if (line.startsWith("event:")) event = line.slice(6).trim();
+            else if (line.startsWith("data:")) data += line.slice(5).trim();
           }
-          log.scrollTop = log.scrollHeight;
+          if (event === "delta") bubble.innerHTML = md((bubble._acc ||= "") + data);
         }
-      } catch {
-        try {
-          const res = await chat({
-            message: text,
-            session_id: (Store?.sessionId ?? "") + "",
-            persona: Store?.persona || "",
-            inactive: Store?.inactiveList?.() || [],
-          });
-          bubble.innerHTML = md(res.response ?? "(no response)");
-        } catch (e2) {
-          bubble.innerHTML = `<em>Error:</em> ${escapeHtml(e2.message)}`;
-        }
+        log.scrollTop = log.scrollHeight;
+      }
+    } catch {
+      try {
+        const res = await chat({
+          message: text,
+          session_id: (Store.sessionId || "") + "",
+          persona: Store.persona || "",
+          inactive: Store.inactiveList?.() || [],
+        });
+        bubble.innerHTML = md(res.response ?? "(no response)");
+      } catch (e2) {
+        bubble.innerHTML = `<em>Error:</em> ${htmlEscape(e2.message)}`;
       }
     }
-
-    btn.addEventListener("click", send);
-    input.addEventListener("keydown", (e) => { if (e.key === "Enter") send(); });
   }
+  btn.addEventListener("click", send);
+  input.addEventListener("keydown", (e) => { if (e.key === "Enter") send(); });
+  return { log, pushUser, pushAssistant };
 }
 
-
-bus.addEventListener("ui:list-action", async (ev) => {
-  const { winId, elementId, action, item } = ev.detail || {};
-  // open from Search results
-  if (winId === "win_search" && elementId === "search_results" && action === "open" && item?.id) {
-    await openSegmentViewer(item.id);
+// ---------------------------------------------------------------------------
+// Chat History & Persona Editor
+// ---------------------------------------------------------------------------
+async function refreshSessions() {
+  const res = await fetch("/sessions", { credentials: "same-origin" });
+  const data = await res.json();
+  const comp = getComponent("win_sessions", "session_list");
+  comp?.render(data);
+}
+async function openSessionsWindow() {
+  if (!document.getElementById("win_sessions")) {
+    spawnWindow({
+      id: "win_sessions",
+      window_type: "window_generic",
+      title: "Chat History",
+      col: "left",
+      unique: true,
+      resizable: true,
+      Elements: [
+        {
+          type: "item_list",
+          id: "session_list",
+          label: "Sessions",
+          item_template: {
+            elements: [
+              { type: "text", bind: "title", class: "li-title" },
+              { type: "text", bind: "created_at", class: "li-meta" },
+              { type: "button", label: "Open", action: "open" }
+            ]
+          }
+        }
+      ]
+    });
   }
-  // open from Segments list (reuse your existing handler if present)
-  if (winId === "win_segments" && elementId === "segment_list" && action === "open" && item?.id) {
-    await openSegmentViewer(item.id);
-  }
-});
+  await refreshSessions();
+}
+async function loadChatHistory(id) {
+  if (!id) return;
+  try {
+    const res = await fetch(`/sessions/${encodeURIComponent(id)}`, { credentials: "same-origin" });
+    if (!res.ok) return;
+    const data = await res.json();
+    chatUI.log.innerHTML = "";
+    for (const [user, assistant] of data.history || []) {
+      chatUI.pushUser(user);
+      const b = chatUI.pushAssistant();
+      b.innerHTML = md(assistant || "");
+    }
+  } catch {}
+}
+function openPersonaEditor() {
+  if (document.getElementById("modal_persona")) return;
+  spawnWindow({
+    id: "modal_persona",
+    window_type: "window_generic",
+    title: "Persona",
+    modal: true,
+    unique: true,
+    resizable: false,
+    Elements: [
+      { type: "text_area", id: "persona_text", rows: 6, value: Store.persona || "" },
+      { type: "button", id: "persona_save", label: "Save" }
+    ]
+  });
+  const modal = document.getElementById("modal_persona");
+  modal.querySelector("#persona_save")?.addEventListener("click", () => {
+    const val = modal.querySelector("#persona_text")?.value || "";
+    Store.persona = val;
+    modal.remove();
+  });
+}
 
-// === ADD: when a doc is selected, refresh segments (assumes you have refreshSegments) ===
-bus.addEventListener("ui:list-select", async (ev) => {
-  const { winId, elementId, item } = ev.detail || {};
-  if (winId === "win_docs" && elementId === "doc_list") {
-    currentSource = item?.id || null;
-    await refreshSegments();
-  }
-});
+// ---------------------------------------------------------------------------
+// Menu & Bus wiring
+// ---------------------------------------------------------------------------
+function setupMenus() {
+  document.querySelector('#user-menu-dropdown [data-action="logout"]')?.addEventListener('click', () => {
+    window.location.href = '/logout';
+  });
+  document.querySelectorAll('#tools-menu-dropdown .menu-item').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const act = btn.dataset.action;
+      if (act === 'tool-chat') document.getElementById('win_chat')?.scrollIntoView();
+      if (act === 'tool-docs') document.getElementById('win_docs')?.scrollIntoView();
+      if (act === 'tool-segments') document.getElementById('win_segments')?.scrollIntoView();
+      if (act === 'tool-sessions') openSessionsWindow();
+      if (act === 'tool-persona') openPersonaEditor();
+    });
+  });
+}
 
+function registerBusHandlers() {
+  bus.addEventListener("ui:list-action", async (ev) => {
+    const { winId, elementId, action, item } = ev.detail || {};
+    if (winId === "win_docs" && elementId === "doc_list") {
+      if (action === "toggle_active") { Store.toggleDoc(item.id); await refreshDocs(); }
+      if (action === "remove")        { try { await removeDocument(item.id); } finally { await refreshDocs(); } }
+    }
+    if (winId === "win_segments" && elementId === "segment_list") {
+      if (action === "open")   await openSegmentViewer(item.id);
+      if (action === "remove") { try { await removeSegment(item.id); } finally { await refreshSegments(); } }
+    }
+    if (winId === "win_search" && elementId === "search_results" && action === "open" && item?.id) {
+      await openSegmentViewer(item.id);
+    }
+    if (winId === "win_sessions" && elementId === "session_list" && action === "open" && item?.session_id) {
+      Store.sessionId = item.session_id;
+      await loadChatHistory(Store.sessionId);
+    }
+  });
+  bus.addEventListener("ui:list-select", async (ev) => {
+    const { winId, elementId, item } = ev.detail || {};
+    if (winId === "win_docs" && elementId === "doc_list") {
+      currentSource = item?.id || null;
+      await refreshSegments();
+    }
+  });
+}
 
-// ── Initial loads ─────────────────────────────────────────────────────────
+// ---------------------------------------------------------------------------
+// Bootstrap
+// ---------------------------------------------------------------------------
+await ensureChatSession();
+const chatUI = createChatWindow();
+createSearchWindow();
+createDocsWindow();
+createSegmentsWindow();
+setupMenus();
+registerBusHandlers();
 await refreshDocs();
 await refreshSegments();
+await loadChatHistory(Store.sessionId);

--- a/app/static/app/js/main.js
+++ b/app/static/app/js/main.js
@@ -21,10 +21,36 @@ async function ensureChatSession() {
   }
 }
 
-function setupMenus() {
+function setupMenus(chatUI) {
+  document.querySelectorAll('.menu').forEach(menu => {
+    const trigger = menu.querySelector('.menu-trigger');
+    const drop = menu.querySelector('.menu-dropdown');
+    if (!trigger || !drop) return;
+    const close = () => {
+      trigger.setAttribute('aria-expanded', 'false');
+      drop.setAttribute('aria-hidden', 'true');
+    };
+    trigger.addEventListener('click', e => {
+      e.stopPropagation();
+      const open = trigger.getAttribute('aria-expanded') === 'true';
+      document.querySelectorAll('.menu .menu-dropdown[aria-hidden="false"]').forEach(d => {
+        d.setAttribute('aria-hidden', 'true');
+        d.previousElementSibling?.setAttribute('aria-expanded', 'false');
+      });
+      if (!open) {
+        trigger.setAttribute('aria-expanded', 'true');
+        drop.setAttribute('aria-hidden', 'false');
+      } else {
+        close();
+      }
+    });
+    document.addEventListener('click', e => { if (!menu.contains(e.target)) close(); });
+  });
+
   document.querySelector('#user-menu-dropdown [data-action="logout"]')?.addEventListener('click', () => {
     window.location.href = '/logout';
   });
+
   document.querySelectorAll('#tools-menu-dropdown .menu-item').forEach(btn => {
     btn.addEventListener('click', () => {
       const act = btn.dataset.action;
@@ -33,6 +59,23 @@ function setupMenus() {
       if (act === 'tool-segments') document.getElementById('win_segments')?.scrollIntoView();
       if (act === 'tool-sessions') openSessionsWindow();
       if (act === 'tool-persona') openPersonaEditor();
+    });
+  });
+
+  document.querySelectorAll('#menu-dropdown .menu-item').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const act = btn.dataset.action;
+      if (act === 'new-chat') {
+        chatUI.log.innerHTML = '';
+        Store.sessionId = '';
+        ensureChatSession();
+      }
+      if (act === 'toggle-search') {
+        const w = document.getElementById('win_search');
+        if (w) w.style.display = w.style.display === 'none' ? '' : 'none';
+      }
+      if (act === 'prompt-templates') alert('Prompt templates not implemented');
+      if (act === 'settings') alert('Settings not implemented');
     });
   });
 }
@@ -68,7 +111,7 @@ const chatUI = createChatWindow();
 createSearchWindow();
 createDocsWindow();
 createSegmentsWindow();
-setupMenus();
+setupMenus(chatUI);
 registerBusHandlers();
 await refreshDocs();
 await refreshSegments();

--- a/app/static/app/js/main.js
+++ b/app/static/app/js/main.js
@@ -256,7 +256,12 @@ function createChatWindow() {
             if (line.startsWith("event:")) event = line.slice(6).trim();
             else if (line.startsWith("data:")) data += line.slice(5).trim();
           }
-          if (event === "delta") bubble.innerHTML = md((bubble._acc ||= "") + data);
+          if (event === "delta") {
+            try { data = JSON.parse(data); } catch {}
+            if (data === ".") continue; // ignore keep-alives
+            bubble._acc = (bubble._acc || "") + data;
+            bubble.innerHTML = md(bubble._acc);
+          }
         }
         log.scrollTop = log.scrollHeight;
       }

--- a/app/static/app/js/sdk.js
+++ b/app/static/app/js/sdk.js
@@ -1,6 +1,11 @@
 // /app/sdk.js
 const JSON_HEADERS = { Accept: "application/json" };
 
+function csrfHeader() {
+  const m = document.cookie.match(/(?:^|;\s*)csrf_token=([^;]+)/);
+  return m ? { 'X-CSRF-Token': decodeURIComponent(m[1]) } : {};
+}
+
 async function ok(res) {
   if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
   return res;
@@ -15,36 +20,36 @@ async function asJsonSafe(res) {
 }
 
 export async function listDocuments() {
-  const res = await ok(await fetch("/documents", { headers: JSON_HEADERS, credentials: "same-origin" }));
+  const res = await ok(await fetch("/documents", { headers: { ...JSON_HEADERS, ...csrfHeader() }, credentials: "same-origin" }));
   return asJsonSafe(res);
 }
 export async function uploadDocuments(files) {
   const fd = new FormData();
   for (const f of files) fd.append("files", f);
-  const res = await ok(await fetch("/upload", { method: "POST", body: fd, credentials: "same-origin" }));
+  const res = await ok(await fetch("/upload", { method: "POST", body: fd, credentials: "same-origin", headers: csrfHeader() }));
   return asJsonSafe(res);
 }
 export async function removeDocument(source) {
   const fd = new FormData();
   fd.append("source", source);
-  const res = await ok(await fetch("/remove", { method: "POST", body: fd, credentials: "same-origin" }));
+  const res = await ok(await fetch("/remove", { method: "POST", body: fd, credentials: "same-origin", headers: csrfHeader() }));
   return asJsonSafe(res);
 }
 
 // in /app/sdk.js
 export async function listSegments(source) {
   const url = source ? `/segments?source=${encodeURIComponent(source)}` : `/segments`;
-  const res = await fetch(url, { headers: { Accept: "application/json" }, credentials: "same-origin" });
+  const res = await fetch(url, { headers: { Accept: "application/json", ...csrfHeader() }, credentials: "same-origin" });
   if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
   return await res.json();
 }
 export async function getSegment(id) {
-  const res = await fetch(`/segments/${encodeURIComponent(id)}`, { headers: { Accept: "application/json" }, credentials: "same-origin" });
+  const res = await fetch(`/segments/${encodeURIComponent(id)}`, { headers: { Accept: "application/json", ...csrfHeader() }, credentials: "same-origin" });
   if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
   return await res.json();
 }
 export async function removeSegment(id) {
-  const res = await fetch(`/segments/${encodeURIComponent(id)}`, { method: "DELETE", headers: { Accept: "application/json" }, credentials: "same-origin" });
+  const res = await fetch(`/segments/${encodeURIComponent(id)}`, { method: "DELETE", headers: { Accept: "application/json", ...csrfHeader() }, credentials: "same-origin" });
   if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
   return await res.json();
 }
@@ -58,7 +63,7 @@ export async function chat({ message, session_id, persona = "", inactive = [] })
   const res = await fetch(`/chat?stream=false`, {
     method: "POST",
     body: fd,
-    headers: { "Accept": "application/json" },
+    headers: { "Accept": "application/json", ...csrfHeader() },
     credentials: "same-origin"
   });
   if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
@@ -75,7 +80,7 @@ export async function chatStream({ message, session_id, persona = "", inactive =
 
   const res = await fetch(`/chat?stream=true`, {
     method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8", "Accept": "*/*" },
+    headers: { "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8", "Accept": "*/*", ...csrfHeader() },
     body: params.toString(),
     credentials: "same-origin",
   });
@@ -93,7 +98,7 @@ export async function searchSegments({ q, top_k = 10, inactive = [] }) {
   params.set("top_k", String(top_k));
   if (inactive?.length) params.set("inactive", JSON.stringify(inactive));
   const res = await fetch(`/search?${params.toString()}`, {
-    headers: { Accept: "application/json" }, credentials: "same-origin"
+    headers: { Accept: "application/json", ...csrfHeader() }, credentials: "same-origin"
   });
   if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
   return await res.json(); // array of segments or {results:[...]}

--- a/app/static/app/js/store.js
+++ b/app/static/app/js/store.js
@@ -1,11 +1,20 @@
 // /app/store.js
 const stored = localStorage.getItem("inactiveDocs");
-const state = { inactiveDocs: new Set(stored ? JSON.parse(stored) : []) };
+const state = {
+  inactiveDocs: new Set(stored ? JSON.parse(stored) : []),
+  sessionId: null,
+  persona: localStorage.getItem("persona") || "",
+};
 
 export const Store = {
+  get sessionId() { return state.sessionId; },
+  set sessionId(id) { state.sessionId = id; },
+  get persona() { return state.persona; },
+  set persona(p) { state.persona = p; localStorage.setItem("persona", p); },
+  inactiveList() { return [...state.inactiveDocs]; },
   isDocActive(id) { return !state.inactiveDocs.has(id); },
   toggleDoc(id) {
     state.inactiveDocs.has(id) ? state.inactiveDocs.delete(id) : state.inactiveDocs.add(id);
     localStorage.setItem("inactiveDocs", JSON.stringify([...state.inactiveDocs]));
-  }
+  },
 };

--- a/app/static/app/js/util.js
+++ b/app/static/app/js/util.js
@@ -1,0 +1,2 @@
+export const htmlEscape = (s="") => s.replaceAll("&","&amp;").replaceAll("<","&lt;").replaceAll(">","&gt;");
+export const md = (s="") => (window.marked?.parse ? window.marked.parse(s) : htmlEscape(s).replaceAll("\n","<br>"));

--- a/app/static/app/js/util.js
+++ b/app/static/app/js/util.js
@@ -1,2 +1,6 @@
 export const htmlEscape = (s="") => s.replaceAll("&","&amp;").replaceAll("<","&lt;").replaceAll(">","&gt;");
 export const md = (s="") => (window.marked?.parse ? window.marked.parse(s) : htmlEscape(s).replaceAll("\n","<br>"));
+export const moveLabelTop = (row) => {
+  const label = row?.querySelector?.(".label");
+  if (label) row.insertBefore(label, row.firstChild);
+};

--- a/app/static/app/js/util.js
+++ b/app/static/app/js/util.js
@@ -1,6 +1,2 @@
 export const htmlEscape = (s="") => s.replaceAll("&","&amp;").replaceAll("<","&lt;").replaceAll(">","&gt;");
 export const md = (s="") => (window.marked?.parse ? window.marked.parse(s) : htmlEscape(s).replaceAll("\n","<br>"));
-export const moveLabelTop = (row) => {
-  const label = row?.querySelector?.(".label");
-  if (label) row.insertBefore(label, row.firstChild);
-};

--- a/app/static/app/js/windows/chat.js
+++ b/app/static/app/js/windows/chat.js
@@ -1,0 +1,108 @@
+import { spawnWindow } from "../framework.js";
+import { chat, chatStream } from "../sdk.js";
+import { Store } from "../store.js";
+import { md, htmlEscape } from "../util.js";
+
+export function createChatWindow() {
+  spawnWindow({
+    id: "win_chat",
+    window_type: "window_generic",
+    title: "Assistant Chat",
+    col: "right",
+    unique: true,
+    resizable: true,
+    Elements: [
+      { type: "text_area", id: "chat_log", rows: 14, value: "" },
+      { type: "text_field", id: "chat_input", placeholder: "Type a message…" }
+    ]
+  });
+  const win = document.getElementById("win_chat");
+  const taRow = win?.querySelector("#chat_log")?.closest(".row");
+  if (!win || !taRow) return {};
+  const log = document.createElement("div");
+  log.id = "chat_log";
+  log.className = "chat-log";
+  taRow.replaceWith(log);
+  const input = win.querySelector("#chat_input");
+  const inputRow = input?.closest(".row");
+  const bar = document.createElement("div");
+  bar.className = "chat-input";
+  const btn = document.createElement("button");
+  btn.type = "button";
+  btn.className = "btn";
+  btn.textContent = "Send";
+  inputRow?.replaceWith(bar);
+  bar.append(input, btn);
+  const pushUser = (text) => {
+    const d = document.createElement("div");
+    d.className = "msg you";
+    d.innerHTML = "You: " + htmlEscape(text);
+    log.appendChild(d);
+    log.scrollTop = log.scrollHeight;
+  };
+  const pushAssistant = () => {
+    const d = document.createElement("div");
+    d.className = "msg assistant";
+    d.innerHTML = "…";
+    log.appendChild(d);
+    log.scrollTop = log.scrollHeight;
+    return d;
+  };
+  async function send() {
+    const text = input.value.trim();
+    if (!text) return;
+    input.value = "";
+    pushUser(text);
+    const bubble = pushAssistant();
+    try {
+      const { reader, decoder } = await chatStream({
+        message: text,
+        session_id: (Store.sessionId || "") + "",
+        persona: Store.persona || "",
+        inactive: Store.inactiveList?.() || [],
+      });
+      let buf = "";
+      let acc = "";
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buf += decoder.decode(value, { stream: true });
+        const chunks = buf.split("\n\n");
+        buf = chunks.pop();
+        for (const chunk of chunks) {
+          let event = "delta", data = "";
+          for (const line of chunk.split("\n")) {
+            if (line.startsWith("event:")) event = line.slice(6).trim();
+            else if (line.startsWith("data:")) data += line.slice(5).trim();
+          }
+          if (event === "delta") {
+            let parsed;
+            try { parsed = JSON.parse(data); } catch {}
+            if (parsed && typeof parsed === "object") {
+              data = parsed.delta ?? parsed.response ?? Object.values(parsed)[0];
+            }
+            if (data === ".") continue;
+            acc += data;
+            bubble.innerHTML = md(acc);
+          }
+        }
+        log.scrollTop = log.scrollHeight;
+      }
+    } catch {
+      try {
+        const res = await chat({
+          message: text,
+          session_id: (Store.sessionId || "") + "",
+          persona: Store.persona || "",
+          inactive: Store.inactiveList?.() || [],
+        });
+        bubble.innerHTML = md(res.response ?? "(no response)");
+      } catch (e2) {
+        bubble.innerHTML = `<em>Error:</em> ${htmlEscape(e2.message)}`;
+      }
+    }
+  }
+  btn.addEventListener("click", send);
+  input.addEventListener("keydown", (e) => { if (e.key === "Enter") send(); });
+  return { log, pushUser, pushAssistant };
+}

--- a/app/static/app/js/windows/chat.js
+++ b/app/static/app/js/windows/chat.js
@@ -78,10 +78,14 @@ export function createChatWindow() {
           if (event === "delta") {
             let parsed;
             try { parsed = JSON.parse(data); } catch {}
-            if (parsed && typeof parsed === "object") {
-              data = parsed.delta ?? parsed.response ?? Object.values(parsed)[0];
+            if (parsed !== undefined) {
+              if (typeof parsed === "object" && parsed) {
+                data = parsed.delta ?? parsed.response ?? Object.values(parsed)[0] ?? "";
+              } else {
+                data = parsed + "";
+              }
             }
-            if (data === ".") continue;
+            if (data === "." || data === "[DONE]") continue;
             acc += data;
             bubble.innerHTML = md(acc);
           }

--- a/app/static/app/js/windows/docs.js
+++ b/app/static/app/js/windows/docs.js
@@ -1,0 +1,68 @@
+import { spawnWindow } from "../framework.js";
+import { listDocuments, uploadDocuments, removeDocument } from "../sdk.js";
+import { getComponent } from "/static/ui/js/components.js";
+import { Store } from "../store.js";
+
+export async function refreshDocs() {
+  const data = await listDocuments();
+  const docs = (data || []).map(d => ({ ...d, active: Store.isDocActive(d.id) }));
+  const comp = getComponent("win_docs", "doc_list");
+  comp?.render(docs);
+}
+
+async function handleUpload(files) {
+  if (!files || !files.length) return;
+  await uploadDocuments(files);
+  document.getElementById("docs_upload")?.clear?.();
+  await refreshDocs();
+}
+
+function moveLabelTop(row) {
+  const label = row?.querySelector(".label");
+  if (label) {
+    row.insertBefore(label, row.firstChild);
+  }
+}
+
+export function createDocsWindow() {
+  spawnWindow({
+    id: "win_docs",
+    window_type: "window_generic",
+    title: "Document Library",
+    col: "left",
+    unique: true,
+    resizable: true,
+    Elements: [
+      {
+        type: "file_upload",
+        id: "docs_upload",
+        label: "Upload",
+        multiple: true,
+        selectLabel: "Choose Files",
+        buttonLabel: "Upload",
+        onUpload: handleUpload,
+      },
+      {
+        type: "item_list",
+        id: "doc_list",
+        label: "Documents",
+        item_template: {
+          elements: [
+            { type: "text", bind: "title", class: "li-title" },
+            { type: "text", bind: "segments", class: "li-meta" },
+            { type: "button", toggle: { prop: "active", on: "Deactivate", off: "Activate", action: "toggle_active" } },
+            { type: "button", label: "Remove", action: "remove", variant: "danger" }
+          ]
+        }
+      }
+    ]
+  });
+  const win = document.getElementById("win_docs");
+  moveLabelTop(win?.querySelector("#docs_upload")?.closest(".row"));
+  moveLabelTop(win?.querySelector("#doc_list")?.closest(".row"));
+}
+
+export async function handleDocAction(action, item) {
+  if (action === "toggle_active") { Store.toggleDoc(item.id); await refreshDocs(); }
+  if (action === "remove")        { try { await removeDocument(item.id); } finally { await refreshDocs(); } }
+}

--- a/app/static/app/js/windows/docs.js
+++ b/app/static/app/js/windows/docs.js
@@ -2,6 +2,7 @@ import { spawnWindow } from "../framework.js";
 import { listDocuments, uploadDocuments, removeDocument } from "../sdk.js";
 import { getComponent } from "/static/ui/js/components.js";
 import { Store } from "../store.js";
+import { moveLabelTop } from "../util.js";
 
 export async function refreshDocs() {
   const data = await listDocuments();
@@ -15,13 +16,6 @@ async function handleUpload(files) {
   await uploadDocuments(files);
   document.getElementById("docs_upload")?.clear?.();
   await refreshDocs();
-}
-
-function moveLabelTop(row) {
-  const label = row?.querySelector(".label");
-  if (label) {
-    row.insertBefore(label, row.firstChild);
-  }
 }
 
 export function createDocsWindow() {

--- a/app/static/app/js/windows/docs.js
+++ b/app/static/app/js/windows/docs.js
@@ -2,7 +2,6 @@ import { spawnWindow } from "../framework.js";
 import { listDocuments, uploadDocuments, removeDocument } from "../sdk.js";
 import { getComponent } from "/static/ui/js/components.js";
 import { Store } from "../store.js";
-import { moveLabelTop } from "../util.js";
 
 export async function refreshDocs() {
   const data = await listDocuments();
@@ -31,6 +30,7 @@ export function createDocsWindow() {
         type: "file_upload",
         id: "docs_upload",
         label: "Upload",
+        label_position: "top",
         multiple: true,
         selectLabel: "Choose Files",
         buttonLabel: "Upload",
@@ -40,6 +40,7 @@ export function createDocsWindow() {
         type: "item_list",
         id: "doc_list",
         label: "Documents",
+        label_position: "top",
         item_template: {
           elements: [
             { type: "text", bind: "title", class: "li-title" },
@@ -51,9 +52,6 @@ export function createDocsWindow() {
       }
     ]
   });
-  const win = document.getElementById("win_docs");
-  moveLabelTop(win?.querySelector("#docs_upload")?.closest(".row"));
-  moveLabelTop(win?.querySelector("#doc_list")?.closest(".row"));
 }
 
 export async function handleDocAction(action, item) {

--- a/app/static/app/js/windows/persona.js
+++ b/app/static/app/js/windows/persona.js
@@ -1,0 +1,24 @@
+import { spawnWindow } from "../framework.js";
+import { Store } from "../store.js";
+
+export function openPersonaEditor() {
+  if (document.getElementById("modal_persona")) return;
+  spawnWindow({
+    id: "modal_persona",
+    window_type: "window_generic",
+    title: "Persona",
+    modal: true,
+    unique: true,
+    resizable: false,
+    Elements: [
+      { type: "text_area", id: "persona_text", rows: 6, value: Store.persona || "" },
+      { type: "button", id: "persona_save", label: "Save" }
+    ]
+  });
+  const modal = document.getElementById("modal_persona");
+  modal.querySelector("#persona_save")?.addEventListener("click", () => {
+    const val = modal.querySelector("#persona_text")?.value || "";
+    Store.persona = val;
+    modal.remove();
+  });
+}

--- a/app/static/app/js/windows/search.js
+++ b/app/static/app/js/windows/search.js
@@ -1,0 +1,58 @@
+import { spawnWindow } from "../framework.js";
+import { searchSegments } from "../sdk.js";
+import { getComponent } from "/static/ui/js/components.js";
+import { Store } from "../store.js";
+
+export function createSearchWindow() {
+  spawnWindow({
+    id: "win_search",
+    window_type: "window_generic",
+    title: "Semantic Search",
+    col: "right",
+    unique: true,
+    resizable: true,
+    Elements: [
+      { type: "text_field", id: "search_q", placeholder: "Search text…" },
+      { type: "number_field", id: "search_k", label: "Top K", value: 10, min: 1, max: 100 },
+      {
+        type: "item_list",
+        id: "search_results",
+        label: "Results",
+        item_template: {
+          elements: [
+            { type: "text", bind: "source", class: "li-title" },
+            { type: "text", bind: "preview", class: "li-subtle" },
+            { type: "button", label: "Open", action: "open" }
+          ]
+        }
+      }
+    ]
+  });
+  const win = document.getElementById("win_search");
+  const qInput = win?.querySelector("#search_q");
+  const kInput = win?.querySelector("#search_k") || { value: 10 };
+  if (qInput) {
+    const qRow = qInput.closest(".row");
+    const bar = document.createElement("div");
+    bar.className = "actions";
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "btn";
+    btn.id = "search_btn";
+    btn.textContent = "Search";
+    bar.appendChild(btn);
+    qRow?.after(bar);
+    async function runSearch() {
+      const q = qInput.value.trim();
+      const k = parseInt(kInput.value || "10", 10);
+      if (!q) return;
+      const inactive = Store?.inactiveList?.() || [];
+      const res = await searchSegments({ q, top_k: k, inactive });
+      const results = Array.isArray(res?.results) ? res.results : (Array.isArray(res) ? res : []);
+      const comp = getComponent("win_search", "search_results");
+      comp?.render(results);
+    }
+    btn.addEventListener("click", runSearch);
+    qInput.addEventListener("keydown", (e) => { if (e.key === "Enter") runSearch(); });
+  }
+}

--- a/app/static/app/js/windows/segments.js
+++ b/app/static/app/js/windows/segments.js
@@ -1,7 +1,7 @@
 import { spawnWindow } from "../framework.js";
 import { listSegments, getSegment, removeSegment } from "../sdk.js";
 import { getComponent } from "/static/ui/js/components.js";
-import { md, htmlEscape, moveLabelTop } from "../util.js";
+import { md, htmlEscape } from "../util.js";
 
 let currentSource = null;
 
@@ -28,6 +28,7 @@ export function createSegmentsWindow() {
         type: "item_list",
         id: "segment_list",
         label: "Segments",
+        label_position: "top",
         item_template: {
           elements: [
             { type: "text", bind: "source",  class: "li-title" },
@@ -40,8 +41,6 @@ export function createSegmentsWindow() {
       }
     ]
   });
-  const win = document.getElementById("win_segments");
-  moveLabelTop(win?.querySelector("#segment_list")?.closest(".row"));
 }
 
 export async function handleSegmentAction(action, item) {

--- a/app/static/app/js/windows/segments.js
+++ b/app/static/app/js/windows/segments.js
@@ -1,7 +1,7 @@
 import { spawnWindow } from "../framework.js";
 import { listSegments, getSegment, removeSegment } from "../sdk.js";
 import { getComponent } from "/static/ui/js/components.js";
-import { md, htmlEscape } from "../util.js";
+import { md, htmlEscape, moveLabelTop } from "../util.js";
 
 let currentSource = null;
 
@@ -27,6 +27,7 @@ export function createSegmentsWindow() {
       {
         type: "item_list",
         id: "segment_list",
+        label: "Segments",
         item_template: {
           elements: [
             { type: "text", bind: "source",  class: "li-title" },
@@ -39,6 +40,8 @@ export function createSegmentsWindow() {
       }
     ]
   });
+  const win = document.getElementById("win_segments");
+  moveLabelTop(win?.querySelector("#segment_list")?.closest(".row"));
 }
 
 export async function handleSegmentAction(action, item) {
@@ -57,27 +60,23 @@ export async function openSegmentViewer(id) {
     unique: false,
     resizable: true,
     Elements: [
-      { type: "text", id: "seg_meta", value: "" },
-      { type: "text", id: "seg_text", value: "" }
+      { type: "text", id: "seg_content", value: "" }
     ]
   });
   const win = document.getElementById(winId);
-  const meta = win?.querySelector("#seg_meta")?.closest(".row")?.querySelector(".value") || win?.querySelector("#seg_meta");
-  const bodyRow = win?.querySelector("#seg_text")?.closest(".row");
-  if (meta) {
-    meta.innerHTML = `
+  const row = win?.querySelector("#seg_content")?.closest(".row");
+  if (row) {
+    const viewer = document.createElement("div");
+    viewer.className = "segment-view";
+    viewer.innerHTML = `
       <div class="kv">
         <div><strong>ID:</strong> ${htmlEscape(seg.id||"")}</div>
         <div><strong>Source:</strong> ${htmlEscape(seg.source||"")}</div>
         <div><strong>Index:</strong> ${htmlEscape(String(seg.segment_index ?? ""))}</div>
         <div><strong>Priority:</strong> ${htmlEscape(seg.priority||"")}</div>
         <div><strong>Chars:</strong> ${htmlEscape(String(seg.start_char ?? ""))}–${htmlEscape(String(seg.end_char ?? ""))}</div>
-      </div>`;
-  }
-  if (bodyRow) {
-    const viewer = document.createElement("div");
-    viewer.className = "segment-view prose";
-    viewer.innerHTML = md(seg.text || seg.preview || "(empty)");
-    bodyRow.replaceWith(viewer);
+      </div>
+      <div class="prose">${md(seg.text || seg.preview || "(empty)")}</div>`;
+    row.replaceWith(viewer);
   }
 }

--- a/app/static/app/js/windows/segments.js
+++ b/app/static/app/js/windows/segments.js
@@ -1,0 +1,83 @@
+import { spawnWindow } from "../framework.js";
+import { listSegments, getSegment, removeSegment } from "../sdk.js";
+import { getComponent } from "/static/ui/js/components.js";
+import { md, htmlEscape } from "../util.js";
+
+let currentSource = null;
+
+export function setSegmentsSource(id) {
+  currentSource = id || null;
+}
+
+export async function refreshSegments() {
+  const segs = await listSegments(currentSource);
+  const comp = getComponent("win_segments", "segment_list");
+  comp?.render(segs || []);
+}
+
+export function createSegmentsWindow() {
+  spawnWindow({
+    id: "win_segments",
+    window_type: "window_generic",
+    title: "DB Segments",
+    col: "right",
+    unique: true,
+    resizable: true,
+    Elements: [
+      {
+        type: "item_list",
+        id: "segment_list",
+        item_template: {
+          elements: [
+            { type: "text", bind: "source",  class: "li-title" },
+            { type: "text", bind: "priority", class: "li-meta"  },
+            { type: "text", bind: "preview",  class: "li-subtle" },
+            { type: "button", label: "Open",   action: "open" },
+            { type: "button", label: "Remove", action: "remove", variant: "danger" }
+          ]
+        }
+      }
+    ]
+  });
+}
+
+export async function handleSegmentAction(action, item) {
+  if (action === "open")   await openSegmentViewer(item.id);
+  if (action === "remove") { try { await removeSegment(item.id); } finally { await refreshSegments(); } }
+}
+
+export async function openSegmentViewer(id) {
+  const seg = await getSegment(id);
+  const winId = `seg_view_${id}`;
+  spawnWindow({
+    id: winId,
+    window_type: "window_generic",
+    title: seg?.source ? `Segment • ${seg.source}` : "Segment",
+    col: "right",
+    unique: false,
+    resizable: true,
+    Elements: [
+      { type: "text", id: "seg_meta", value: "" },
+      { type: "text", id: "seg_text", value: "" }
+    ]
+  });
+  const win = document.getElementById(winId);
+  const meta = win?.querySelector("#seg_meta")?.closest(".row")?.querySelector(".value") || win?.querySelector("#seg_meta");
+  const bodyRow = win?.querySelector("#seg_text")?.closest(".row");
+  if (meta) {
+    meta.innerHTML = `
+      <div class="kv">
+        <div><strong>ID:</strong> ${htmlEscape(seg.id||"")}</div>
+        <div><strong>Source:</strong> ${htmlEscape(seg.source||"")}</div>
+        <div><strong>Index:</strong> ${htmlEscape(String(seg.segment_index ?? ""))}</div>
+        <div><strong>Priority:</strong> ${htmlEscape(seg.priority||"")}</div>
+        <div><strong>Chars:</strong> ${htmlEscape(String(seg.start_char ?? ""))}–${htmlEscape(String(seg.end_char ?? ""))}</div>
+      </div>`;
+  }
+  if (bodyRow) {
+    const viewer = document.createElement("div");
+    viewer.className = "segment-view prose";
+    viewer.innerHTML = md(seg.text || seg.preview || "(empty)");
+    bodyRow.replaceWith(viewer);
+  }
+}

--- a/app/static/app/js/windows/sessions.js
+++ b/app/static/app/js/windows/sessions.js
@@ -1,0 +1,54 @@
+import { spawnWindow } from "../framework.js";
+import { getComponent } from "/static/ui/js/components.js";
+import { Store } from "../store.js";
+import { md } from "../util.js";
+
+export async function refreshSessions() {
+  const res = await fetch("/sessions", { credentials: "same-origin" });
+  const data = await res.json();
+  const comp = getComponent("win_sessions", "session_list");
+  comp?.render(data);
+}
+
+export async function openSessionsWindow() {
+  if (!document.getElementById("win_sessions")) {
+    spawnWindow({
+      id: "win_sessions",
+      window_type: "window_generic",
+      title: "Chat History",
+      col: "left",
+      unique: true,
+      resizable: true,
+      Elements: [
+        {
+          type: "item_list",
+          id: "session_list",
+          label: "Sessions",
+          item_template: {
+            elements: [
+              { type: "text", bind: "title", class: "li-title" },
+              { type: "text", bind: "created_at", class: "li-meta" },
+              { type: "button", label: "Open", action: "open" }
+            ]
+          }
+        }
+      ]
+    });
+  }
+  await refreshSessions();
+}
+
+export async function loadChatHistory(chatUI, id) {
+  if (!id) return;
+  try {
+    const res = await fetch(`/sessions/${encodeURIComponent(id)}`, { credentials: "same-origin" });
+    if (!res.ok) return;
+    const data = await res.json();
+    chatUI.log.innerHTML = "";
+    for (const [user, assistant] of data.history || []) {
+      chatUI.pushUser(user);
+      const b = chatUI.pushAssistant();
+      b.innerHTML = md(assistant || "");
+    }
+  } catch {}
+}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -16,7 +16,6 @@
           <button id="menu-trigger" class="menu-trigger" aria-haspopup="true" aria-expanded="false">Menu ▾</button>
           <div id="menu-dropdown" class="menu-dropdown" role="menu" aria-hidden="true">
             <button class="menu-item" data-action="new-chat" role="menuitem">New Chat</button>
-            <button class="menu-item" data-action="edit-persona" role="menuitem">Persona…</button>
             <button class="menu-item" data-action="toggle-search" role="menuitem">Context</button>
             <div class="menu-sep"></div>
             <button class="menu-item" data-action="prompt-templates" role="menuitem">Prompt Templates</button>
@@ -28,6 +27,7 @@
           <div id="tools-menu-dropdown" class="menu-dropdown" role="menu" aria-hidden="true">
             <button class="menu-item" data-action="tool-chat" role="menuitem">Chat Assistant</button>
             <button class="menu-item" data-action="tool-docs" role="menuitem">Documents Library</button>
+            <button class="menu-item" data-action="tool-persona" role="menuitem">Persona Editor</button>
             <button class="menu-item" data-action="tool-sessions" role="menuitem">Chat History</button>
             <button class="menu-item" data-action="tool-segments" role="menuitem">DB Segments</button>
           </div>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -30,6 +30,7 @@
             <button class="menu-item" data-action="tool-persona" role="menuitem">Persona Editor</button>
             <button class="menu-item" data-action="tool-sessions" role="menuitem">Chat History</button>
             <button class="menu-item" data-action="tool-segments" role="menuitem">DB Segments</button>
+            <button class="menu-item" data-action="tool-refresh" role="menuitem">Reload Data</button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Refactor main.js into modular windows and menu wiring
- Add CSRF header support and session/persona state store
- Implement chat history window, persona editor modal, and logout menu

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ce7dcd2ac832c97ee4154421e326c