### PR TITLE
Add storage schemas and interface for future persistence

### DIFF
--- a/core/storage/__init__.py
+++ b/core/storage/__init__.py
@@ -1,0 +1,13 @@
+"""Storage schemas and interfaces."""
+
+from .schemas import User, Session, Document, Prompt, ChatMessage
+from .interface import StorageBackend
+
+__all__ = [
+    "User",
+    "Session",
+    "Document",
+    "Prompt",
+    "ChatMessage",
+    "StorageBackend",
+]

--- a/core/storage/interface.py
+++ b/core/storage/interface.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import List, Optional
+
+from .schemas import User, Session, Document, Prompt, ChatMessage
+
+
+class StorageBackend(ABC):
+    """Abstract interface describing persistence operations."""
+
+    # Users
+    @abstractmethod
+    def get_user(self, user_id: str) -> Optional[User]: ...
+
+    @abstractmethod
+    def save_user(self, user: User) -> None: ...
+
+    @abstractmethod
+    def delete_user(self, user_id: str) -> None: ...
+
+    # Sessions
+    @abstractmethod
+    def get_session(self, session_id: str) -> Optional[Session]: ...
+
+    @abstractmethod
+    def save_session(self, session: Session) -> None: ...
+
+    @abstractmethod
+    def delete_session(self, session_id: str) -> None: ...
+
+    # Documents
+    @abstractmethod
+    def list_documents(self, owner_id: Optional[str] = None) -> List[Document]: ...
+
+    @abstractmethod
+    def get_document(self, doc_id: str) -> Optional[Document]: ...
+
+    @abstractmethod
+    def save_document(self, doc: Document) -> None: ...
+
+    @abstractmethod
+    def delete_document(self, doc_id: str) -> None: ...
+
+    # Prompts
+    @abstractmethod
+    def list_prompts(self, owner_id: Optional[str] = None) -> List[Prompt]: ...
+
+    @abstractmethod
+    def get_prompt(self, prompt_id: str) -> Optional[Prompt]: ...
+
+    @abstractmethod
+    def save_prompt(self, prompt: Prompt) -> None: ...
+
+    @abstractmethod
+    def delete_prompt(self, prompt_id: str) -> None: ...
+
+    # Chat history
+    @abstractmethod
+    def append_chat_message(self, message: ChatMessage) -> None: ...
+
+    @abstractmethod
+    def get_chat_history(self, user_id: str, limit: Optional[int] = None) -> List[ChatMessage]: ...
+
+    @abstractmethod
+    def clear_chat_history(self, user_id: str) -> None: ...

--- a/core/storage/schemas.py
+++ b/core/storage/schemas.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional, Literal
+
+from pydantic import BaseModel, Field
+
+
+class User(BaseModel):
+    """User account information."""
+
+    id: str
+    name: Optional[str] = None
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class Session(BaseModel):
+    """Authenticated user session."""
+
+    id: str
+    user_id: str
+    issued_at: datetime = Field(default_factory=datetime.utcnow)
+    expires_at: Optional[datetime] = None
+    last_seen: Optional[datetime] = None
+    ua_hash: Optional[str] = None
+    ip_net: Optional[str] = None
+    attrs: dict = Field(default_factory=dict)
+
+
+class Document(BaseModel):
+    """Ingested document metadata."""
+
+    id: str
+    owner_id: str
+    title: Optional[str] = None
+    path: Optional[str] = None
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    meta: dict = Field(default_factory=dict)
+
+
+class Prompt(BaseModel):
+    """Prompt template description."""
+
+    id: str
+    name: str
+    description: Optional[str] = None
+    content: Optional[str] = None
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class ChatMessage(BaseModel):
+    """Single message within a chat history."""
+
+    id: str
+    user_id: str
+    session_id: Optional[str] = None
+    role: Literal["user", "assistant", "system"] = "user"
+    content: str
+    created_at: datetime = Field(default_factory=datetime.utcnow)


### PR DESCRIPTION
## Summary
- add Pydantic models for users, sessions, documents, prompts, and chat messages
- introduce abstract `StorageBackend` interface to outline CRUD operations

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f4bfc6518832c93f7416bf548fe46