### PR TITLE
feat: store model configuration per user

### DIFF
--- a/core/llm/__init__.py
+++ b/core/llm/__init__.py
@@ -2,13 +2,10 @@ from typing import Optional
 from .base import BaseLLM
 from .ollama_llm import OllamaLLM
 from .openai_llm import OpenAILLM
-import os
 
 DEFAULT_PROVIDER = "ollama"
 
-def make_llm(provider: str, model: Optional[str]) -> BaseLLM:
-    if provider == "openai" and os.getenv("OPENAI_API_KEY"):
-        return OpenAILLM(model=model)
+def make_llm(provider: str, model: Optional[str], **kwargs) -> BaseLLM:
     if provider == "openai":
-        return OpenAILLM(model=model)
-    return OllamaLLM(model=model)
+        return OpenAILLM(model=model, api_key=kwargs.get("api_key"))
+    return OllamaLLM(model=model, base_url=kwargs.get("base_url"))

--- a/core/llm/ollama_llm.py
+++ b/core/llm/ollama_llm.py
@@ -3,22 +3,25 @@ import requests, json
 from config import OLLAMA_BASE_URL, OLLAMA_MODEL
 from .base import BaseLLM
 
-GENERATE_URL = f"{OLLAMA_BASE_URL}/api/generate"
 
 class OllamaLLM(BaseLLM):
-    def __init__(self, model: str | None = None, **kwargs: Any) -> None:
+    def __init__(self, model: str | None = None, base_url: str | None = None, **kwargs: Any) -> None:
+        self.base_url = base_url or OLLAMA_BASE_URL
         super().__init__(model or OLLAMA_MODEL)
+
+    def _generate_url(self) -> str:
+        return f"{self.base_url}/api/generate"
 
     def generate_text(self, prompt: str, **kwargs: Any) -> str:
         payload = {"model": self.model, "prompt": prompt, "stream": False}
-        resp = requests.post(GENERATE_URL, json=payload, timeout=kwargs.get("timeout", 120))
+        resp = requests.post(self._generate_url(), json=payload, timeout=kwargs.get("timeout", 120))
         resp.raise_for_status()
         data = resp.json()
         return data.get("response", "")
 
     def stream_text(self, prompt: str, **kwargs: Any) -> Iterator[str]:
         payload = {"model": self.model, "prompt": prompt, "stream": True}
-        with requests.post(GENERATE_URL, json=payload, stream=True, timeout=kwargs.get("timeout", None)) as r:
+        with requests.post(self._generate_url(), json=payload, stream=True, timeout=kwargs.get("timeout", None)) as r:
             r.raise_for_status()
             for line in r.iter_lines(decode_unicode=True):
                 if not line:

--- a/core/llm/openai_llm.py
+++ b/core/llm/openai_llm.py
@@ -1,9 +1,12 @@
 from typing import Any, Iterator
 from .base import BaseLLM
 
+
 class OpenAILLM(BaseLLM):
     """Placeholder OpenAI backend. Wire the SDK when ready."""
-    def __init__(self, model: str | None = None, **kwargs: Any) -> None:
+
+    def __init__(self, model: str | None = None, api_key: str | None = None, **kwargs: Any) -> None:
+        self.api_key = api_key
         super().__init__(model or "gpt-4o-mini")
 
     def generate_text(self, prompt: str, **kwargs: Any) -> str:

--- a/core/prompts/renderer.py
+++ b/core/prompts/renderer.py
@@ -146,8 +146,16 @@ def stream_llm(prompt: str, user_id: Optional[str] = None) -> Iterable[str]:
 
     s = _resolve_settings(user_id)
     provider = getattr(s, "llm_provider", "ollama")
-    model = getattr(s, "llm_model", "") or None
-    llm = make_llm(provider, model)
+    kwargs = {}
+    if provider == "ollama":
+        model = getattr(getattr(s, "ollama", None), "model", None) or None
+        kwargs["base_url"] = getattr(getattr(s, "ollama", None), "base_url", None)
+    elif provider == "openai":
+        model = getattr(getattr(s, "openai", None), "model", None) or None
+        kwargs["api_key"] = getattr(getattr(s, "openai", None), "api_key", None)
+    else:
+        model = None
+    llm = make_llm(provider, model, **kwargs)
     return llm.stream_text(prompt)
 
 def ask_llm(prompt: str, user_id: Optional[str] = None) -> str:
@@ -155,8 +163,16 @@ def ask_llm(prompt: str, user_id: Optional[str] = None) -> str:
 
     s = _resolve_settings(user_id)
     provider = getattr(s, "llm_provider", "ollama")
-    model = getattr(s, "llm_model", "") or None
-    llm = make_llm(provider, model)
+    kwargs = {}
+    if provider == "ollama":
+        model = getattr(getattr(s, "ollama", None), "model", None) or None
+        kwargs["base_url"] = getattr(getattr(s, "ollama", None), "base_url", None)
+    elif provider == "openai":
+        model = getattr(getattr(s, "openai", None), "model", None) or None
+        kwargs["api_key"] = getattr(getattr(s, "openai", None), "api_key", None)
+    else:
+        model = None
+    llm = make_llm(provider, model, **kwargs)
     return llm.generate_text(prompt)
 
 def update_summary(old_summary: str, last_user: str, last_assistant: str, user_id: Optional[str]=None) -> str:


### PR DESCRIPTION
## Summary
- track Ollama and OpenAI model details in user settings
- wire renderer and LLM factory to use provider-specific config
- preserve nested settings when patching user records

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f79a0b5a8832c977e3a89de02cf6d