### PR TITLE
feat: store per-user model configuration

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -9,6 +9,21 @@ from .prompts import loader as prompt_loader
 USERS_DIR = Path("users")
 USERS_DIR.mkdir(parents=True, exist_ok=True)
 
+
+class OllamaSettings(BaseModel):
+    """Configuration for an Ollama model endpoint."""
+
+    host: str = "http://localhost:11434"
+    model: str = ""
+
+
+class OpenAISettings(BaseModel):
+    """Configuration for an OpenAI ChatGPT model."""
+
+    model: str = ""
+    api_key: str = ""
+
+
 class UserSettings(BaseModel):
     user_id: str
     llm_provider: Literal["ollama", "openai"] = "ollama"
@@ -17,6 +32,8 @@ class UserSettings(BaseModel):
     temperature: float = 0.2
     top_p: float = 0.95
     max_tokens: int = 512
+    ollama: OllamaSettings = Field(default_factory=OllamaSettings)
+    openai: OpenAISettings = Field(default_factory=OpenAISettings)
 
 def _user_path(user_id: str) -> Path:
     """Location of the settings file for ``user_id``."""

--- a/db/models.py
+++ b/db/models.py
@@ -35,6 +35,7 @@ class User(Base):
     email: str = Column(String, unique=True, nullable=False)
     hashed_password: str = Column(String, nullable=False)
     created_at: datetime = Column(DateTime, default=datetime.utcnow)
+    llm_config = Column(JSON, default=dict)
 
     sessions: List["WebSession"] = relationship("WebSession", back_populates="user")
     chat_sessions: List["ChatSession"] = relationship(

--- a/docs/DATABASE_SCHEMA.md
+++ b/docs/DATABASE_SCHEMA.md
@@ -8,7 +8,7 @@ metadata.
 
 ## Tables
 
-- **users** – basic user records with email and hashed password.
+- **users** – basic user records with email, hashed password and per-user LLM configuration.
 - **web_sessions** – login sessions issued by the HTTPS interface.
 - **chat_sessions** – individual chat conversations.
 - **chat_exchanges** – messages within a chat session.

--- a/tests/test_user_settings.py
+++ b/tests/test_user_settings.py
@@ -1,0 +1,24 @@
+import uuid
+from pathlib import Path
+
+from core import settings
+
+
+def test_model_specific_settings_persist(tmp_path):
+    user_id = f"test-{uuid.uuid4()}"
+    file_path = settings.USERS_DIR / f"{user_id}.json"
+    if file_path.exists():
+        file_path.unlink()
+    s = settings.load_settings(user_id)
+    assert s.ollama.model == ""
+    patch = {
+        "ollama": {"model": "llama2", "host": "http://1.2.3.4:11434"},
+        "openai": {"model": "gpt-4", "api_key": "sk-test"},
+    }
+    settings.update_settings(user_id, patch)
+    s2 = settings.load_settings(user_id)
+    assert s2.ollama.model == "llama2"
+    assert s2.ollama.host == "http://1.2.3.4:11434"
+    assert s2.openai.model == "gpt-4"
+    assert s2.openai.api_key == "sk-test"
+    file_path.unlink()


### PR DESCRIPTION
## Summary
- expand user settings with model-specific configs for Ollama and OpenAI
- mirror per-user LLM settings in the `User` ORM model
- document `users` table change and add regression test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f7c486c64832ca66a35071aee04e9