### PR TITLE
feat: allow chat to select LLM service

### DIFF
--- a/api/routers/chat.py
+++ b/api/routers/chat.py
@@ -18,6 +18,7 @@ store = SessionStore()
 async def chat(
     message: str = Form(...),
     session_id: str = Form(...),
+    service_id: Optional[str] = Form(None),
     persona: str = Form(""),
     inactive: Optional[str] = Form(None),
     template_id: str = Form("rag_chat"),
@@ -33,6 +34,8 @@ async def chat(
     session_id:
         Identifier for the chat session.  A new session is created if the
         provided ID does not exist.
+    service_id:
+        Identifier of the LLM service to use for this request.
     persona:
         Optional persona string to bias responses.
     inactive:
@@ -57,6 +60,7 @@ async def chat(
         session.inactive_sources = json.loads(inactive)
     req = ChatRequest(
         user_id=session.user_id,
+        service_id=service_id,
         message=message,
         persona=persona or session.persona,
         template_id=template_id,
@@ -130,6 +134,7 @@ async def chat(
 async def chat_stream(
     message: str = Form(...),
     session_id: str = Form(...),
+    service_id: Optional[str] = Form(None),
     persona: str = Form(""),
     inactive: Optional[str] = Form(None),
     template_id: str = Form("rag_chat"),
@@ -140,6 +145,7 @@ async def chat_stream(
     return await chat(
         message=message,
         session_id=session_id,
+        service_id=service_id,
         persona=persona,
         inactive=inactive,
         template_id=template_id,

--- a/core/models.py
+++ b/core/models.py
@@ -25,6 +25,7 @@ class ChatRequest(BaseModel):
     """Parameters controlling a single chat turn."""
 
     user_id: Optional[str] = None
+    service_id: Optional[str] = None
     message: str
     template_id: str = "rag_chat"
     top_k: int = 8

--- a/core/pipeline.py
+++ b/core/pipeline.py
@@ -40,7 +40,7 @@ def chat_once(req: ChatRequest) -> ChatResponse:
         persona=req.persona,
         template_id=req.template_id,
     )
-    text = renderer.ask_llm(prompt, user_id=req.user_id)
+    text = renderer.ask_llm(prompt, user_id=req.user_id, service_id=req.service_id)
     return ChatResponse(text=text, sources=_to_sources(context), usage={})
 
 
@@ -62,6 +62,6 @@ def chat_stream(req: ChatRequest) -> Iterator[ChatChunk]:
     )
     meta = json.dumps({"top_k": req.top_k, "template": req.template_id})
     yield ChatChunk(type="meta", text=meta)
-    for token in renderer.stream_llm(prompt, user_id=req.user_id):
+    for token in renderer.stream_llm(prompt, user_id=req.user_id, service_id=req.service_id):
         yield ChatChunk(type="delta", text=token)
     yield ChatChunk(type="done", sources=_to_sources(context), usage={})

--- a/tests/test_api_chat.py
+++ b/tests/test_api_chat.py
@@ -6,6 +6,7 @@ from core.models import ChatChunk
 from core import pipeline
 from core.prompts import renderer
 import app.main as main
+from app.core.llm import provider
 
 client = TestClient(main.app)
 
@@ -20,10 +21,15 @@ def test_sse_stream(monkeypatch):
     monkeypatch.setattr(renderer, "generate_title", lambda s: "title")
     monkeypatch.setattr(renderer, "update_summary", lambda old, u, a: "summary")
 
+    sid = str(provider.list_services()[0].id)
     with client.stream(
         "POST",
         "/chat?stream=true",
-        data={"message": "hi", "session_id": "12345678-1234-1234-1234-123456789012"},
+        data={
+            "message": "hi",
+            "session_id": "12345678-1234-1234-1234-123456789012",
+            "service_id": sid,
+        },
         cookies={"session": "test"},
     ) as res:
         assert res.status_code == 200

--- a/tests/test_api_smoke.py
+++ b/tests/test_api_smoke.py
@@ -9,6 +9,7 @@ from core.models import ChatResponse, Source
 from core.prompts import renderer
 from core.rag import retriever
 from app.auth.session import SessionValidationMiddleware
+from app.core.llm import provider
 
 
 async def _bypass(self, request, call_next):
@@ -26,9 +27,14 @@ def test_chat_endpoint(monkeypatch):
     monkeypatch.setattr(pipeline, "chat_once", fake_chat_once)
     monkeypatch.setattr(renderer, "generate_title", lambda s: "title")
     monkeypatch.setattr(renderer, "update_summary", lambda old, u, a: "summary")
+    sid = str(provider.list_services()[0].id)
     res = client.post(
         "/chat",
-        data={"message": "hi", "session_id": "12345678-1234-1234-1234-123456789012"},
+        data={
+            "message": "hi",
+            "session_id": "12345678-1234-1234-1234-123456789012",
+            "service_id": sid,
+        },
         cookies={"session": "test"},
     )
     assert res.status_code == 200

--- a/tests/test_core_pipeline.py
+++ b/tests/test_core_pipeline.py
@@ -6,7 +6,9 @@ from core import pipeline
 
 
 def test_chat_once_returns_sources(monkeypatch):
-    monkeypatch.setattr(pipeline.renderer, "ask_llm", lambda prompt, user_id=None: "answer")
+    monkeypatch.setattr(
+        pipeline.renderer, "ask_llm", lambda prompt, user_id=None, service_id=None: "answer"
+    )
     monkeypatch.setattr(
         pipeline.retriever,
         "search",

--- a/tests/test_core_smoke.py
+++ b/tests/test_core_smoke.py
@@ -6,7 +6,7 @@ from core import pipeline
 
 
 def test_chat_once(monkeypatch):
-    def fake_ask(prompt, user_id=None):
+    def fake_ask(prompt, user_id=None, service_id=None):
         return "ok"
     monkeypatch.setattr(pipeline.renderer, "ask_llm", fake_ask)
     monkeypatch.setattr(
@@ -18,7 +18,7 @@ def test_chat_once(monkeypatch):
 
 
 def test_chat_stream(monkeypatch):
-    def fake_stream(prompt, user_id=None):
+    def fake_stream(prompt, user_id=None, service_id=None):
         yield "a"
         yield "b"
     monkeypatch.setattr(pipeline.renderer, "stream_llm", fake_stream)


### PR DESCRIPTION
## Summary
- allow `/chat` endpoints to accept an optional `service_id`
- plumb `service_id` through `ChatRequest` and pipeline
- resolve LLM backend via service registry when `service_id` is supplied

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a23d7d94ac832c9da8a8e51d9f687f