### PR TITLE
Add user retrieval API

### DIFF
--- a/api/routers/users.py
+++ b/api/routers/users.py
@@ -1,0 +1,35 @@
+from fastapi import APIRouter, HTTPException
+from typing import List
+from datetime import datetime
+from pydantic import BaseModel, ConfigDict
+
+from core.db import SessionLocal, User
+
+
+class UserInfo(BaseModel):
+    id: str
+    email: str
+    created_at: datetime | None = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+router = APIRouter(prefix="/api/users", tags=["users"])
+
+
+@router.get("", response_model=List[UserInfo])
+def list_users():
+    """Return all users."""
+    with SessionLocal() as db:
+        users = db.query(User).all()
+        return [UserInfo.model_validate(u) for u in users]
+
+
+@router.get("/{user_id}", response_model=UserInfo)
+def get_user(user_id: str):
+    """Return a single user by identifier."""
+    with SessionLocal() as db:
+        user = db.query(User).filter(User.id == user_id).first()
+        if not user:
+            raise HTTPException(status_code=404, detail="user not found")
+        return UserInfo.model_validate(user)

--- a/app/main.py
+++ b/app/main.py
@@ -9,6 +9,7 @@ from api.routers.chat import router as chat_router
 from api.routers.search import router as search_router
 from api.routers.ingest import router as ingest_router
 from api.routers.settings import router as settings_router
+from api.routers.users import router as users_router
 from app.routes.api_sessions import router as sessions_router
 from app.routes.api_segments import router as segments_router
 from app.routes.api_llm import router as llm_router
@@ -45,3 +46,4 @@ app.include_router(sessions_router)
 app.include_router(segments_router)
 app.include_router(settings_router)
 app.include_router(llm_router)
+app.include_router(users_router)

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -15,6 +15,8 @@
 | `/segments` | GET | List stored text segments |
 | `/segments/{id}` | GET/DELETE | Retrieve or delete a segment |
 | `/settings/{user}` | GET/PATCH | Retrieve or partially update user settings |
+| `/api/users` | GET | List users |
+| `/api/users/{id}` | GET | Retrieve a user record |
 | `/prompt-templates` | GET/PUT | List or create prompt templates |
 
 All endpoints return JSON except `/chat-stream`, which emits `meta`, `delta` and `done` events.

--- a/tests/test_user_api.py
+++ b/tests/test_user_api.py
@@ -1,0 +1,37 @@
+import uuid
+
+from fastapi.testclient import TestClient
+import app.main as main
+from app.auth.session import SessionValidationMiddleware
+from core.db import SessionLocal, User
+
+
+async def _bypass(self, request, call_next):
+    return await call_next(request)
+
+
+SessionValidationMiddleware.dispatch = _bypass
+
+client = TestClient(main.app)
+
+
+def test_user_retrieval():
+    user_id = f"test-{uuid.uuid4()}"
+    email = f"{user_id}@example.com"
+    with SessionLocal() as db:
+        db.add(User(id=user_id, email=email, hashed_password="!"))
+        db.commit()
+
+    res = client.get(f"/api/users/{user_id}")
+    assert res.status_code == 200
+    data = res.json()
+    assert data["id"] == user_id
+    assert data["email"] == email
+
+    res = client.get("/api/users")
+    assert res.status_code == 200
+    users = res.json()
+    assert any(u["id"] == user_id for u in users)
+
+    res = client.get("/api/users/does-not-exist")
+    assert res.status_code == 404


### PR DESCRIPTION
## Summary
- expose REST endpoints to list and fetch user records
- wire user router into FastAPI app and document the API

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a2471f7038832c911149cba8047c4d