### PR TITLE
Make LLM selection user-specific

### DIFF
--- a/app/core/llm/adapter_mock.py
+++ b/app/core/llm/adapter_mock.py
@@ -224,6 +224,8 @@ def get_selection(user_id: str) -> LLMSelection:
 
 
 def set_selection(sel: LLMSelection) -> LLMSelection:
+    if not sel.user_id:
+        raise ValueError("user_id required")
     selections[sel.user_id] = sel
     _save_selection()
     return sel

--- a/app/core/llm/schemas.py
+++ b/app/core/llm/schemas.py
@@ -40,6 +40,7 @@ class LLMModel(BaseModel):
     id: UUID
     service_id: UUID
     name: str
+    model_name: str
     modality: Optional[str] = None
     context_window: Optional[int] = None
     supports_tools: bool = False
@@ -50,6 +51,7 @@ class LLMModel(BaseModel):
 class ModelCreate(BaseModel):
     service_id: UUID
     name: constr(strip_whitespace=True, min_length=1)
+    model_name: constr(strip_whitespace=True, min_length=1)
     modality: Optional[str] = None
     context_window: Optional[conint(ge=1, le=1048576)] = None
     supports_tools: bool = False
@@ -58,6 +60,7 @@ class ModelCreate(BaseModel):
 
 class ModelUpdate(BaseModel):
     name: Optional[str] = None
+    model_name: Optional[str] = None
     modality: Optional[str] = None
     context_window: Optional[conint(ge=1, le=1048576)] = None
     supports_tools: Optional[bool] = None

--- a/app/core/llm/schemas.py
+++ b/app/core/llm/schemas.py
@@ -65,6 +65,6 @@ class ModelUpdate(BaseModel):
 
 
 class LLMSelection(BaseModel):
-    user_id: str
+    user_id: Optional[str] = None
     service_id: Optional[UUID] = None
     model_id: Optional[UUID] = None

--- a/app/routes/api_llm.py
+++ b/app/routes/api_llm.py
@@ -57,7 +57,11 @@ def get_models(service_id: UUID = Query(...)):
 
 @router.post("/models", response_model=LLMModel, status_code=201)
 def post_model(payload: ModelCreate):
-    """Create a new model entry."""
+    """Create a new model entry.
+
+    ``model_name`` specifies the provider's model identifier while
+    ``name`` is used as a human-friendly label.
+    """
     try:
         return provider.create_model(payload)
     except ValueError as e:

--- a/app/routes/api_llm.py
+++ b/app/routes/api_llm.py
@@ -95,6 +95,6 @@ def get_selection(request: Request):
 def put_selection(payload: LLMSelection, request: Request):
     """Persist the user's preferred service/model."""
     user_id = getattr(request.state, "user_id", "local-user")
-    if not payload.user_id:
-        payload.user_id = user_id
+    # Always associate selection with the requesting user
+    payload.user_id = user_id
     return provider.set_selection(payload)

--- a/tests/test_llm_registry.py
+++ b/tests/test_llm_registry.py
@@ -39,9 +39,10 @@ def test_llm_registry_crud():
     mid = res.json()["id"]
 
     # Selection
-    sel_payload = {"user_id": "", "service_id": sid, "model_id": mid}
+    sel_payload = {"service_id": sid, "model_id": mid}
     res = client.put("/api/llm/selection", json=sel_payload)
     assert res.status_code == 200
+    assert res.json()["user_id"] == "local-user"
     res = client.get("/api/llm/selection")
     assert res.json()["model_id"] == mid
 


### PR DESCRIPTION
## Summary
- allow user_id to be omitted when setting LLM selection
- always tie selection updates to the requesting user
- verify selection round-trip in the registry test

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a27edf0d6c832c9bb703874adda9ae